### PR TITLE
Feature/keyword kkesong

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,10 @@ out/
 # src/main/resources/application.properties 파일 무시
 /src/main/resources/application.properties
 
+# Spring Boot configuration
+src/main/resources/application.yml
+src/main/resources/application-*.yml
+src/main/resources/application.properties
+src/main/resources/application-*.properties
+
+

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,13 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	// for 스웨거 사용
+	// 🟢 Swagger UI(springdoc-openapi)
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+	// 🟢 @Valid 등 검증 어노테이션 사용할 경우
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hackathon_5/Yogiyong_In/DTO/KeywordGetItemDto.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/DTO/KeywordGetItemDto.java
@@ -1,0 +1,24 @@
+package com.hackathon_5.Yogiyong_In.DTO;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(name = "KeywordGetItemDto", description = "키워드 목록의 한 항목 DTO")
+public class KeywordGetItemDto {
+
+    @Schema(description = "키워드 ID", example = "1")
+    private Integer keywordId;   // ERD: INT → DTO도 Integer로
+
+    @Schema(description = "키워드명", example = "불꽃놀이")
+    private String name;         // DB: keyword_name
+
+    @Schema(description = "아이콘 이미지 URL(또는 경로)", example = "/icons/1.svg")
+    private String iconUrl;      // DB: image_path → 서비스에서 URL 변환 후 세팅
+
+    @Schema(description = "사용자 선택 여부 (includeSelected=true일 때만 포함)", example = "true", nullable = true)
+    private Boolean selected;    // 로그인+includeSelected=true일 때만 값, 아니면 null(응답에서 제외)
+}

--- a/src/main/java/com/hackathon_5/Yogiyong_In/DTO/KeywordScrollResDto.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/DTO/KeywordScrollResDto.java
@@ -1,0 +1,12 @@
+package com.hackathon_5.Yogiyong_In.DTO;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class KeywordScrollResDto {
+    private List<KeywordGetItemDto> items; // [{keywordId, name, iconUrl, selected?}]
+    private Integer nextCursor;            // 다음 시작 keywordId (없으면 null)
+    private boolean hasNext;
+}

--- a/src/main/java/com/hackathon_5/Yogiyong_In/DTO/KeywordUpdateReqDto.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/DTO/KeywordUpdateReqDto.java
@@ -1,0 +1,17 @@
+package com.hackathon_5.Yogiyong_In.DTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import java.util.List;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+@Schema(name = "KeywordUpdateReqDto", description = "선택할 키워드 ID 목록 요청 DTO (PUT Body)")
+public class KeywordUpdateReqDto {
+
+    @Schema(
+            description = "선택할 키워드 ID 배열",
+            example = "[1, 2, 5]"
+    )
+    private List<Integer> keywordIds;
+}

--- a/src/main/java/com/hackathon_5/Yogiyong_In/config/OpenApiConfig.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/config/OpenApiConfig.java
@@ -1,0 +1,27 @@
+package com.hackathon_5.Yogiyong_In.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.*;
+import io.swagger.v3.oas.models.security.*;
+import io.swagger.v3.oas.models.Components;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityScheme bearer = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT");
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("해커톤 5팀 축제 추천 API")
+                        .version("v1")
+                        .description("키워드/리뷰/즐겨찾기 엔드포인트"))
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+                .components(new Components().addSecuritySchemes("bearerAuth", bearer));
+    }
+}

--- a/src/main/java/com/hackathon_5/Yogiyong_In/config/OpenApiConfig.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/config/OpenApiConfig.java
@@ -1,27 +1,30 @@
+// src/main/java/com/hackathon_5/Yogiyong_In/config/OpenApiConfig.java
 package com.hackathon_5.Yogiyong_In.config;
 
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.info.*;
-import io.swagger.v3.oas.models.security.*;
 import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class OpenApiConfig {
-    @Bean
-    public OpenAPI openAPI() {
-        SecurityScheme bearer = new SecurityScheme()
-                .type(SecurityScheme.Type.HTTP)
-                .scheme("bearer")
-                .bearerFormat("JWT");
 
+    @Bean
+    public OpenAPI customOpenAPI() {
         return new OpenAPI()
                 .info(new Info()
-                        .title("해커톤 5팀 축제 추천 API")
+                        .title("Festival Recommendation API")
                         .version("v1")
-                        .description("키워드/리뷰/즐겨찾기 엔드포인트"))
-                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
-                .components(new Components().addSecuritySchemes("bearerAuth", bearer));
+                        .description("Swagger UI for Festival Recommendation"))
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")))
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
     }
 }

--- a/src/main/java/com/hackathon_5/Yogiyong_In/config/SecurityConfig.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/config/SecurityConfig.java
@@ -1,0 +1,28 @@
+package com.hackathon_5.Yogiyong_In.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    private static final String[] SWAGGER_WHITELIST = {
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/docs"
+    };
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable());
+        http.authorizeHttpRequests(auth -> auth
+                .requestMatchers(SWAGGER_WHITELIST).permitAll()
+                .anyRequest().permitAll() // 모든 요청 허용!
+        );
+        return http.build();
+    }
+}
+// 요거는 테스트 용입니당_ 실제 개발시 수정할 예정

--- a/src/main/java/com/hackathon_5/Yogiyong_In/controller/KeywordController.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/controller/KeywordController.java
@@ -1,8 +1,8 @@
+// src/main/java/com/hackathon_5/Yogiyong_In/controller/KeywordController.java
 package com.hackathon_5.Yogiyong_In.controller;
 
 import com.hackathon_5.Yogiyong_In.DTO.KeywordScrollResDto;
 import com.hackathon_5.Yogiyong_In.DTO.KeywordUpdateReqDto;
-import com.hackathon_5.Yogiyong_In.DTO.KeywordGetItemDto;
 import com.hackathon_5.Yogiyong_In.service.KeywordService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -11,13 +11,21 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.Map;
+
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 @Tag(name = "Keyword", description = "키워드 조회/선택 API")
 @RestController
@@ -30,30 +38,34 @@ public class KeywordController {
     @Operation(
             summary = "키워드 목록(스크롤)",
             description = """
-                cursor(마지막 keywordId) 이후 데이터를 size만큼 반환.
-                includeSelected=true 이고 (로그인 or X-Device-Id 제공) 상태면 selected 필드를 포함합니다.
-                게스트 사용자는 X-Device-Id 헤더를 보내 주세요.
-                """
+                cursor(마지막 keywordId) 이후 데이터를 size만큼 반환합니다.
+                ✅ 조회도 로그인 필수(Authorization: Bearer ...).
+                includeSelected=true면 사용자 선택 여부도 함께 내려줍니다.
+                """,
+            security = { @SecurityRequirement(name = "bearerAuth") }
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content)
+            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content)
     })
+    @PreAuthorize("isAuthenticated()") // ✅ 조회도 로그인 강제
     @GetMapping("/keywords")
     public ResponseEntity<KeywordScrollResDto> getKeywords(
             @Parameter(description = "이 커서(마지막 keywordId) 이후부터 조회")
             @RequestParam(required = false) Integer cursor,
             @Parameter(description = "가져올 개수(기본 30, 최대 100)")
             @RequestParam(defaultValue = "30") Integer size,
-            @Parameter(description = "선택 여부 표시 포함 (게스트는 X-Device-Id 필요)")
-            @RequestParam(defaultValue = "false") boolean includeSelected,
-            @RequestHeader(value = "Authorization", required = false) String authHeader,
-            @RequestHeader(value = "X-Device-Id", required = false) String deviceId
+            @Parameter(description = "선택 여부 포함(로그인 필수)")
+            @RequestParam(defaultValue = "false") boolean includeSelected
     ) {
-        int s = (size == null || size <= 0) ? 30 : Math.min(size, 100);
+        String userId = currentUserIdOrThrow();          // ✅ 항상 로그인 필요
+        int s = (size <= 0) ? 30 : Math.min(size, 100);
+
+        // includeSelected는 응답에 선택 여부를 실을지 말지의 토글로만 사용
+        boolean effectiveIncludeSelected = includeSelected;
+
         return ResponseEntity.ok(
-                // 새 오버로드: 게스트도 포함 처리
-                keywordService.getKeywordsScroll(cursor, s, includeSelected, authHeader, deviceId)
+                keywordService.getKeywordsScroll(cursor, s, effectiveIncludeSelected, userId)
         );
     }
 
@@ -61,61 +73,92 @@ public class KeywordController {
             summary = "내 선택 키워드 전체 교체",
             description = """
                 전달한 keywordIds만 선택 상태로 저장합니다(전체 교체).
-                로그인은 Authorization 헤더를, 비로그인은 X-Device-Id 헤더(고정 UUID)를 보내세요.
-                expand=names 로 보내면 ID+이름을 함께 반환합니다.
-                """
+                로그인 사용자 전용입니다.
+                expand=names 를 사용하면 ID+이름을 함께 반환합니다.
+                """,
+            security = { @SecurityRequirement(name = "bearerAuth") }
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "저장 성공"),
-            @ApiResponse(responseCode = "400", description = "유효하지 않은 요청/헤더 누락", content = @Content)
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 키워드", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content)
     })
     @Parameters({
-            @Parameter(name = "expand", description = "names 사용 시 ID+이름 반환 (ex. ?expand=names)", schema = @Schema(allowableValues = {"names"}))
+            @Parameter(
+                    name = "expand",
+                    description = "names 사용 시 ID+이름 반환 (예: ?expand=names)",
+                    schema = @Schema(allowableValues = {"names"})
+            )
     })
+    @PreAuthorize("isAuthenticated()")
     @PutMapping("/me/selected-keywords")
     public ResponseEntity<?> replaceMyKeywords(
             @RequestBody KeywordUpdateReqDto body,
-            @RequestHeader(value = "Authorization", required = false) String authHeader,
-            @RequestHeader(value = "X-Device-Id", required = false) String deviceId,
             @RequestParam(name = "expand", required = false) String expand
     ) {
-        // 서비스에서 로그인/게스트 판별 + 저장
-        keywordService.replaceUserKeywords(authHeader, deviceId, body.getKeywordIds());
+        String userId = currentUserIdOrThrow();
+
+        keywordService.replaceUserKeywords(userId, body.getKeywordIds());
 
         if ("names".equalsIgnoreCase(expand)) {
-            List<KeywordGetItemDto> items = keywordService.getSelectedKeywordsWithNames(authHeader, deviceId);
+            var items = keywordService.getSelectedKeywordsWithNames(userId);
             return ResponseEntity.ok(Map.of(
                     "success", true,
-                    "data", Map.of("selectedKeywords", items),
+                    "data", Map.of("userId", userId, "selectedKeywords", items),
                     "error", null
             ));
         } else {
             List<Integer> ids = (body.getKeywordIds() == null) ? List.of() : body.getKeywordIds();
             return ResponseEntity.ok(Map.of(
                     "success", true,
-                    "data", Map.of("selectedKeywordIds", ids),
+                    "data", Map.of("userId", userId, "selectedKeywordIds", ids),
                     "error", null
             ));
         }
     }
 
-    // (선택) Admin/Legacy API
     @Deprecated
     @Operation(
             summary = "(Admin/Legacy) 특정 유저의 선택 키워드 전체 교체",
-            description = "일반 사용자는 자신과 일치하는 userId만 허용됩니다. 신규로는 /api/me/selected-keywords 사용을 권장합니다."
+            description = "일반 사용자는 자신과 일치하는 userId만 허용됩니다. 신규로는 /api/me/selected-keywords 사용 권장.",
+            security = { @SecurityRequirement(name = "bearerAuth") }
     )
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "저장 성공(본문 없음)"),
-            @ApiResponse(responseCode = "400", description = "유효하지 않은 키워드", content = @Content)
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 키워드", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content)
     })
+    @PreAuthorize("isAuthenticated()")
     @PutMapping("/users/{userId}/keywords")
     public ResponseEntity<Void> updateUserKeywords(
             @PathVariable String userId,
             @RequestBody KeywordUpdateReqDto body
     ) {
-        // 서비스 최신 시그니처(2-파라미터)로 호출
+        String me = currentUserIdOrThrow();
+        if (!me.equals(userId)) {
+            throw new ResponseStatusException(UNAUTHORIZED, "다른 사용자의 키워드는 수정할 수 없습니다.");
+        }
         keywordService.replaceUserKeywords(userId, body.getKeywordIds());
         return ResponseEntity.noContent().build();
+    }
+
+    /* ===== 공통 유틸: SecurityContext → userId 추출 ===== */
+    private String currentUserIdOrNull() {
+        var ctx = SecurityContextHolder.getContext();
+        if (ctx == null) return null;
+        Authentication auth = ctx.getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) return null;
+        Object p = auth.getPrincipal();
+        if (p == null) return null;
+
+        if (p instanceof String s && !"anonymousUser".equals(s)) return s;
+        if (p instanceof UserDetails ud) return ud.getUsername();
+        return null;
+    }
+
+    private String currentUserIdOrThrow() {
+        String uid = currentUserIdOrNull();
+        if (uid == null) throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
+        return uid;
     }
 }

--- a/src/main/java/com/hackathon_5/Yogiyong_In/controller/KeywordController.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/controller/KeywordController.java
@@ -1,9 +1,121 @@
 package com.hackathon_5.Yogiyong_In.controller;
 
+import com.hackathon_5.Yogiyong_In.DTO.KeywordScrollResDto;
+import com.hackathon_5.Yogiyong_In.DTO.KeywordUpdateReqDto;
+import com.hackathon_5.Yogiyong_In.DTO.KeywordGetItemDto;
+import com.hackathon_5.Yogiyong_In.service.KeywordService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+import java.util.Map;
+
+@Tag(name = "Keyword", description = "키워드 조회/선택 API")
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class KeywordController {
+
+    private final KeywordService keywordService;
+
+    @Operation(
+            summary = "키워드 목록(스크롤)",
+            description = """
+                cursor(마지막 keywordId) 이후 데이터를 size만큼 반환.
+                includeSelected=true 이고 (로그인 or X-Device-Id 제공) 상태면 selected 필드를 포함합니다.
+                게스트 사용자는 X-Device-Id 헤더를 보내 주세요.
+                """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content)
+    })
+    @GetMapping("/keywords")
+    public ResponseEntity<KeywordScrollResDto> getKeywords(
+            @Parameter(description = "이 커서(마지막 keywordId) 이후부터 조회")
+            @RequestParam(required = false) Integer cursor,
+            @Parameter(description = "가져올 개수(기본 30, 최대 100)")
+            @RequestParam(defaultValue = "30") Integer size,
+            @Parameter(description = "선택 여부 표시 포함 (게스트는 X-Device-Id 필요)")
+            @RequestParam(defaultValue = "false") boolean includeSelected,
+            @RequestHeader(value = "Authorization", required = false) String authHeader,
+            @RequestHeader(value = "X-Device-Id", required = false) String deviceId
+    ) {
+        int s = (size == null || size <= 0) ? 30 : Math.min(size, 100);
+        return ResponseEntity.ok(
+                // 새 오버로드: 게스트도 포함 처리
+                keywordService.getKeywordsScroll(cursor, s, includeSelected, authHeader, deviceId)
+        );
+    }
+
+    @Operation(
+            summary = "내 선택 키워드 전체 교체",
+            description = """
+                전달한 keywordIds만 선택 상태로 저장합니다(전체 교체).
+                로그인은 Authorization 헤더를, 비로그인은 X-Device-Id 헤더(고정 UUID)를 보내세요.
+                expand=names 로 보내면 ID+이름을 함께 반환합니다.
+                """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "저장 성공"),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 요청/헤더 누락", content = @Content)
+    })
+    @Parameters({
+            @Parameter(name = "expand", description = "names 사용 시 ID+이름 반환 (ex. ?expand=names)", schema = @Schema(allowableValues = {"names"}))
+    })
+    @PutMapping("/me/selected-keywords")
+    public ResponseEntity<?> replaceMyKeywords(
+            @RequestBody KeywordUpdateReqDto body,
+            @RequestHeader(value = "Authorization", required = false) String authHeader,
+            @RequestHeader(value = "X-Device-Id", required = false) String deviceId,
+            @RequestParam(name = "expand", required = false) String expand
+    ) {
+        // 서비스에서 로그인/게스트 판별 + 저장
+        keywordService.replaceUserKeywords(authHeader, deviceId, body.getKeywordIds());
+
+        if ("names".equalsIgnoreCase(expand)) {
+            List<KeywordGetItemDto> items = keywordService.getSelectedKeywordsWithNames(authHeader, deviceId);
+            return ResponseEntity.ok(Map.of(
+                    "success", true,
+                    "data", Map.of("selectedKeywords", items),
+                    "error", null
+            ));
+        } else {
+            List<Integer> ids = (body.getKeywordIds() == null) ? List.of() : body.getKeywordIds();
+            return ResponseEntity.ok(Map.of(
+                    "success", true,
+                    "data", Map.of("selectedKeywordIds", ids),
+                    "error", null
+            ));
+        }
+    }
+
+    // (선택) Admin/Legacy API
+    @Deprecated
+    @Operation(
+            summary = "(Admin/Legacy) 특정 유저의 선택 키워드 전체 교체",
+            description = "일반 사용자는 자신과 일치하는 userId만 허용됩니다. 신규로는 /api/me/selected-keywords 사용을 권장합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "저장 성공(본문 없음)"),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 키워드", content = @Content)
+    })
+    @PutMapping("/users/{userId}/keywords")
+    public ResponseEntity<Void> updateUserKeywords(
+            @PathVariable String userId,
+            @RequestBody KeywordUpdateReqDto body
+    ) {
+        // 서비스 최신 시그니처(2-파라미터)로 호출
+        keywordService.replaceUserKeywords(userId, body.getKeywordIds());
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/hackathon_5/Yogiyong_In/domain/Keyword.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/domain/Keyword.java
@@ -1,0 +1,21 @@
+package com.hackathon_5.Yogiyong_In.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "keywords")
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class Keyword {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "keyword_id", nullable = false)
+    private Integer keywordId; // ERD: INT
+
+    @Column(name = "keyword_name", length = 50, nullable = false)
+    private String keywordName;
+
+    @Column(name = "image_path", length = 225) // ERD: 225
+    private String imagePath;
+}

--- a/src/main/java/com/hackathon_5/Yogiyong_In/domain/User.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/domain/User.java
@@ -1,19 +1,23 @@
 package com.hackathon_5.Yogiyong_In.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import jakarta.persistence.*;
+import lombok.*;
 
 @Entity
-@Getter@Setter
-@NoArgsConstructor
+@Table(name = "users")
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
 public class User {
-    @Id
-    public String userId;
-    public String password;
-    public String nickname;
-    public int birthYear;
 
+    @Id
+    @Column(name = "user_id", length = 20, nullable = false)
+    private String userId;
+
+    @Column(name = "password", length = 200, nullable = false)
+    private String password;
+
+    @Column(name = "nickname", length = 20, nullable = false, unique = true)
+    private String nickname;
+
+    @Column(name = "birth_year")
+    private Integer birthYear; // NULL 허용
 }

--- a/src/main/java/com/hackathon_5/Yogiyong_In/domain/UserKeyword.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/domain/UserKeyword.java
@@ -1,0 +1,30 @@
+package com.hackathon_5.Yogiyong_In.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "user_keywords")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserKeyword {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_keyword_id")
+    private Integer id; // PK
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user; // FK → users.user_id
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "keyword_id", nullable = false)
+    private Keyword keyword; // FK → keywords.keyword_id
+
+    @Column(name = "is_selected", nullable = false)
+    private Boolean isSelected;
+}

--- a/src/main/java/com/hackathon_5/Yogiyong_In/repository/KeywordRepository.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/repository/KeywordRepository.java
@@ -1,0 +1,22 @@
+package com.hackathon_5.Yogiyong_In.repository;
+
+import com.hackathon_5.Yogiyong_In.domain.Keyword;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface KeywordRepository extends JpaRepository<Keyword, Integer> {
+
+    @Query("""
+      select k
+        from Keyword k
+       where (:cursor is null or k.keywordId > :cursor)
+       order by k.keywordId asc
+    """)
+    List<Keyword> findScroll(@Param("cursor") Integer cursor, Pageable pageable);
+
+    // ✅ 추가
+    List<Keyword> findByKeywordIdIn(List<Integer> keywordIds);
+}

--- a/src/main/java/com/hackathon_5/Yogiyong_In/repository/UserKeywordRepository.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/repository/UserKeywordRepository.java
@@ -1,0 +1,40 @@
+package com.hackathon_5.Yogiyong_In.repository;
+
+import com.hackathon_5.Yogiyong_In.domain.UserKeyword;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface UserKeywordRepository extends JpaRepository<UserKeyword, Integer> {
+
+    // 현재 페이지에 뜬 키워드들 중, 해당 유저가 선택한 것만 조회
+    @Query("""
+      select uk from UserKeyword uk
+       where uk.user.userId = :userId
+         and uk.keyword.keywordId in :keywordIds
+         and uk.isSelected = true
+    """)
+    List<UserKeyword> findSelectedIn(
+            @Param("userId") String userId,
+            @Param("keywordIds") Collection<Integer> keywordIds
+    );
+
+    // 해당 유저의 기존 선택을 전부 false로
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+      update UserKeyword uk
+         set uk.isSelected = false
+       where uk.user.userId = :userId
+         and uk.isSelected = true
+    """)
+    int clearSelections(@Param("userId") String userId);
+
+    // 특정 유저가 특정 키워드를 선택한 적이 있는지 확인 (있으면 반환)
+    Optional<UserKeyword> findByUser_UserIdAndKeyword_KeywordId(String userId, Integer keywordId);
+
+    // ✅ 추가: 해당 유저의 "현재 선택된" 키워드 전체 조회 (expand=names 로직에서 사용)
+    List<UserKeyword> findByUser_UserIdAndIsSelectedTrue(String userId);
+}

--- a/src/main/java/com/hackathon_5/Yogiyong_In/repository/UserKeywordRepository.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/repository/UserKeywordRepository.java
@@ -32,9 +32,12 @@ public interface UserKeywordRepository extends JpaRepository<UserKeyword, Intege
     """)
     int clearSelections(@Param("userId") String userId);
 
-    // 특정 유저가 특정 키워드를 선택한 적이 있는지 확인 (있으면 반환)
+    // 단일 키워드 선택 여부
     Optional<UserKeyword> findByUser_UserIdAndKeyword_KeywordId(String userId, Integer keywordId);
 
-    // ✅ 추가: 해당 유저의 "현재 선택된" 키워드 전체 조회 (expand=names 로직에서 사용)
+    // 현재 페이지 키워드들 중 선택된 것들
+    List<UserKeyword> findByUser_UserIdAndKeyword_KeywordIdIn(String userId, Collection<Integer> keywordIds);
+
+    // ✅ 추가: 해당 유저의 "현재 선택된" 모든 키워드 (expand=names에서 사용)
     List<UserKeyword> findByUser_UserIdAndIsSelectedTrue(String userId);
 }

--- a/src/main/java/com/hackathon_5/Yogiyong_In/repository/UserRepository.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/repository/UserRepository.java
@@ -1,0 +1,6 @@
+package com.hackathon_5.Yogiyong_In.repository;
+
+import com.hackathon_5.Yogiyong_In.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, String> {}

--- a/src/main/java/com/hackathon_5/Yogiyong_In/service/KeywordService.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/service/KeywordService.java
@@ -7,149 +7,45 @@ import com.hackathon_5.Yogiyong_In.domain.User;
 import com.hackathon_5.Yogiyong_In.domain.UserKeyword;
 import com.hackathon_5.Yogiyong_In.repository.KeywordRepository;
 import com.hackathon_5.Yogiyong_In.repository.UserKeywordRepository;
-import com.hackathon_5.Yogiyong_In.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class KeywordService {
 
     private final KeywordRepository keywordRepository;
     private final UserKeywordRepository userKeywordRepository;
-    private final UserRepository userRepository;
 
-    // 예: "https://cdn.example.com". 비워두면 toIconUrl에서 상대경로 처리
-    private static final String ICON_BASE = "";
+    private static final String ICON_BASE = ""; // 예: "https://cdn.example.com"
 
-    // =====================================================
-    // 유저 식별: 로그인(JWT) 우선, 아니면 deviceId 기반 게스트
-    // =====================================================
-    private String resolveUserId(String authHeader, String deviceId) {
-        log.debug("[resolveUserId] authHeader='{}', deviceId='{}'", authHeader, deviceId);
-
-        // 1) 로그인 사용자 우선 (TODO: 실제 JWT 파싱으로 교체)
-        String userId = extractUserIdOrNull(authHeader);
-        log.debug("[resolveUserId] extractUserIdOrNull -> {}", userId);
-        if (userId != null) return userId;
-
-        // 2) 비로그인: Device-Id 기반 게스트 생성/보장
-        if (deviceId != null && !deviceId.isBlank()) {
-            log.debug("[resolveUserId] deviceId 존재 -> ensureGuestUser");
-            return ensureGuestUser(deviceId);
-        }
-
-        // 3) 둘 다 없으면 400 성격
-        log.error("[resolveUserId] Authorization/X-Device-Id 둘 다 없음 -> IllegalArgumentException");
-        throw new IllegalArgumentException("Authorization 또는 X-Device-Id 헤더가 필요합니다.");
-    }
-
-    // 게스트 user_id를 20자 이내로 안전 축약: "g:" + sha256(deviceId) 12자리
-    private String compactGuestId(String deviceId) {
-        try {
-            MessageDigest md = MessageDigest.getInstance("SHA-256");
-            byte[] digest = md.digest(deviceId.getBytes(StandardCharsets.UTF_8));
-            String hex = java.util.HexFormat.of().formatHex(digest);
-            String shortHex = hex.substring(0, 12);
-            String result = "g:" + shortHex; // 총 14자
-            log.debug("[compactGuestId] deviceId='{}' -> '{}'", deviceId, result);
-            return result;
-        } catch (Exception e) {
-            String fallback = "g:" + Integer.toHexString(deviceId.hashCode());
-            log.warn("[compactGuestId] SHA-256 실패 -> fallback '{}', reason={}", fallback, e.toString());
-            return fallback;
-        }
-    }
-
-    /**
-     * 게스트 유저를 보장/생성한다.
-     * public + @Transactional 로 둬서 프록시 트랜잭션이 적용되도록 함.
-     */
-    @Transactional
-    public String ensureGuestUser(String deviceId) {
-        log.debug("[ensureGuestUser] START deviceId='{}'", deviceId);
-        String userId = "guest:" + deviceId;
-        if (userId.length() > 20) {
-            userId = compactGuestId(deviceId); // 20자 이내 보장
-        }
-        if (userRepository.existsById(userId)) {
-            log.debug("[ensureGuestUser] 이미 존재 -> userId='{}'", userId);
-            return userId;
-        }
-
-        String base = "guest_" + Math.abs(deviceId.hashCode());
-        String nick = base.substring(0, Math.min(20, base.length()));
-
-        // 닉네임 UNIQUE 충돌에 대비해 최대 5회 재시도
-        for (int i = 0; i < 5; i++) {
-            try {
-                User user = User.builder()
-                        .userId(userId)
-                        .password(UUID.randomUUID().toString()) // NOT NULL 충족 + 의미 없는 랜덤 문자열
-                        .nickname(nick)
-                        .birthYear(null)
-                        .build();
-                userRepository.saveAndFlush(user);
-                log.info("[ensureGuestUser] 게스트 생성 성공 userId='{}', nickname='{}'", userId, nick);
-                return userId;
-            } catch (DataIntegrityViolationException dup) {
-                log.warn("[ensureGuestUser] 닉네임 충돌 재시도 idx={}, base='{}'", i, base);
-                String suffix = "_" + i;
-                int cut = Math.max(0, 20 - suffix.length());
-                nick = base.substring(0, Math.min(cut, base.length())) + suffix;
-            }
-        }
-
-        // 최후의 수단: 랜덤 닉네임
-        String rndNick = UUID.randomUUID().toString().replace("-", "").substring(0, 20);
-        User user = User.builder()
-                .userId(userId)
-                .password(UUID.randomUUID().toString())
-                .nickname(rndNick)
-                .birthYear(null)
-                .build();
-        userRepository.save(user);
-        log.info("[ensureGuestUser] 랜덤 닉네임으로 최종 생성 userId='{}', nickname='{}'", userId, rndNick);
-        return userId;
-    }
-
-    // ===========================================
-    // [기존 유지] authHeader만 받는 버전 (로그인 전제)
-    // ===========================================
-    @Transactional(readOnly = true)
-    public KeywordScrollResDto getKeywordsScroll(Integer cursor, int size, boolean includeSelected, String authHeader) {
-        log.debug("[getKeywordsScroll-basic] cursor={}, size={}, includeSelected={}, authHeader='{}'",
-                cursor, size, includeSelected, authHeader);
-
+    /** 컨트롤러가 전달하는 userIdOrNull(비로그인이면 null) 기반으로 동작 */
+    public KeywordScrollResDto getKeywordsScroll(Integer cursor, int size, boolean includeSelected, String userIdOrNull) {
         int s = size <= 0 ? 30 : Math.min(size, 100);
 
+        // 커서 기반 슬라이스 조회 (레포에 findScroll(cursor, pageable) 있다고 가정)
         List<Keyword> slice = keywordRepository.findScroll(cursor, PageRequest.of(0, s + 1));
         boolean hasNext = slice.size() > s;
         if (hasNext) slice = slice.subList(0, s);
-        log.debug("[getKeywordsScroll-basic] slice.size={}, hasNext={}", slice.size(), hasNext);
-
-        String userId = extractUserIdOrNull(authHeader);
-        log.debug("[getKeywordsScroll-basic] resolved userId='{}'", userId);
 
         Set<Integer> selectedIds = Collections.emptySet();
-
-        if (includeSelected && userId != null && !slice.isEmpty()) {
+        if (includeSelected && userIdOrNull != null && !slice.isEmpty()) {
             List<Integer> ids = slice.stream().map(Keyword::getKeywordId).toList();
-            log.debug("[getKeywordsScroll-basic] includeSelected ids={}", ids);
-            selectedIds = userKeywordRepository.findSelectedIn(userId, ids).stream()
+
+            // 표준 메서드로 교체(레포에 없으면 추가): findByUser_UserIdAndKeyword_KeywordIdIn
+            selectedIds = userKeywordRepository
+                    .findByUser_UserIdAndKeyword_KeywordIdIn(userIdOrNull, ids).stream()
+                    .filter(UserKeyword::getIsSelected)
                     .map(uk -> uk.getKeyword().getKeywordId())
                     .collect(Collectors.toSet());
-            log.debug("[getKeywordsScroll-basic] selectedIds={}", selectedIds);
         }
 
         final Set<Integer> finalSelectedIds = selectedIds;
@@ -159,14 +55,13 @@ public class KeywordService {
                         .keywordId(k.getKeywordId())
                         .name(k.getKeywordName())
                         .iconUrl(toIconUrl(k.getImagePath()))
-                        .selected(includeSelected && userId != null
+                        .selected(includeSelected && userIdOrNull != null
                                 ? finalSelectedIds.contains(k.getKeywordId())
                                 : null)
                         .build())
                 .toList();
 
         Integer nextCursor = items.isEmpty() ? null : items.get(items.size() - 1).getKeywordId();
-        log.debug("[getKeywordsScroll-basic] items={}, nextCursor={}", items.size(), nextCursor);
 
         return KeywordScrollResDto.builder()
                 .items(items)
@@ -175,128 +70,41 @@ public class KeywordService {
                 .build();
     }
 
-    // ===================================================
-    // [개선] deviceId 포함 버전: includeSelected일 때만 게스트 보장(Lazy)
-    // ===================================================
-    @Transactional(readOnly = true)
-    public KeywordScrollResDto getKeywordsScroll(
-            Integer cursor, int size, boolean includeSelected,
-            String authHeader, String deviceId
-    ) {
-        log.debug("[getKeywordsScroll-extended] cursor={}, size={}, includeSelected={}, authHeader='{}', deviceId='{}'",
-                cursor, size, includeSelected, authHeader, deviceId);
-
-        final String uid;
-        if (includeSelected) {
-            // 선택표시 계산이 필요할 때에만 userId 해석/게스트 보장
-            String tmp;
-            try {
-                tmp = resolveUserId(authHeader, deviceId);
-            } catch (IllegalArgumentException e) {
-                log.warn("[getKeywordsScroll-extended] userId 해석 실패(includeSelected=true) -> 선택표시 미표시, reason={}", e.getMessage());
-                tmp = null; // 선택표시 불가
-            }
-            uid = tmp;
-        } else {
-            uid = null; // 조회만 할 때는 게스트 생성 안 함
-        }
-        log.debug("[getKeywordsScroll-extended] resolved uid='{}'", uid);
-
-        int s = size <= 0 ? 30 : Math.min(size, 100);
-
-        List<Keyword> slice = keywordRepository.findScroll(cursor, PageRequest.of(0, s + 1));
-        boolean hasNext = slice.size() > s;
-        if (hasNext) slice = slice.subList(0, s);
-        log.debug("[getKeywordsScroll-extended] slice.size={}, hasNext={}", slice.size(), hasNext);
-
-        Set<Integer> selectedIds = Collections.emptySet();
-        if (includeSelected && uid != null && !slice.isEmpty()) {
-            List<Integer> ids = slice.stream().map(Keyword::getKeywordId).toList();
-            log.debug("[getKeywordsScroll-extended] includeSelected ids={}", ids);
-            selectedIds = userKeywordRepository.findSelectedIn(uid, ids).stream()
-                    .map(uk -> uk.getKeyword().getKeywordId())
-                    .collect(Collectors.toSet());
-            log.debug("[getKeywordsScroll-extended] selectedIds={}", selectedIds);
-        }
-        final Set<Integer> finalSelectedIds = selectedIds;
-
-        List<KeywordGetItemDto> items = slice.stream()
-                .map(k -> KeywordGetItemDto.builder()
-                        .keywordId(k.getKeywordId())
-                        .name(k.getKeywordName())
-                        .iconUrl(toIconUrl(k.getImagePath()))
-                        .selected(includeSelected && uid != null
-                                ? finalSelectedIds.contains(k.getKeywordId())
-                                : null)
-                        .build())
-                .toList();
-
-        Integer nextCursor = items.isEmpty() ? null : items.get(items.size() - 1).getKeywordId();
-        log.debug("[getKeywordsScroll-extended] items={}, nextCursor={}", items.size(), nextCursor);
-
-        return KeywordScrollResDto.builder()
-                .items(items)
-                .nextCursor(nextCursor)
-                .hasNext(hasNext)
-                .build();
-    }
-
-    // ===========================================
-    // 선택 교체(업서트): 전체 false → 전달된 것만 true
-    // ===========================================
+    /** 저장은 인증 전제: 컨트롤러에서 이미 userId를 보장 */
     @Transactional
     public void replaceUserKeywords(String userId, List<Integer> keywordIds) {
-        log.debug("[replaceUserKeywords-direct] START userId='{}', keywordIds={}", userId, keywordIds);
-
         // 전체 해제
-        int updated = userKeywordRepository.clearSelections(userId);
-        log.debug("[replaceUserKeywords-direct] clearSelections updatedRows={}", updated);
+        userKeywordRepository.clearSelections(userId);
 
-        if (keywordIds == null || keywordIds.isEmpty()) {
-            log.debug("[replaceUserKeywords-direct] keywordIds 비어있음 -> END");
-            return;
+        List<Integer> ids = (keywordIds == null) ? List.of()
+                : keywordIds.stream().filter(Objects::nonNull).distinct().toList();
+        if (ids.isEmpty()) return;
+
+        // 존재 검증(잘못된 ID는 400)
+        Set<Integer> existing = keywordRepository.findByKeywordIdIn(ids).stream()
+                .map(Keyword::getKeywordId)
+                .collect(Collectors.toSet());
+        List<Integer> bad = ids.stream().filter(id -> !existing.contains(id)).toList();
+        if (!bad.isEmpty()) {
+            throw new ResponseStatusException(BAD_REQUEST, "invalid keywordIds: " + bad);
         }
 
-        // 전달된 것만 선택 true로 업서트
-        for (Integer kid : keywordIds) {
-            log.debug("[replaceUserKeywords-direct] upsert keywordId={}", kid);
-            var existing = userKeywordRepository.findByUser_UserIdAndKeyword_KeywordId(userId, kid);
-            if (existing.isPresent()) {
-                log.trace("[replaceUserKeywords-direct] 기존 존재 -> set isSelected=true & save");
-                existing.get().setIsSelected(true);
-                userKeywordRepository.save(existing.get());
-            } else {
-                log.trace("[replaceUserKeywords-direct] 신규 생성 -> save");
-                UserKeyword uk = new UserKeyword();
-                uk.setUser(User.builder().userId(userId).build());
-                uk.setKeyword(Keyword.builder().keywordId(kid).build());
-                uk.setIsSelected(true);
-                userKeywordRepository.save(uk);
-            }
+        // 전달된 것만 true로 업서트
+        for (Integer kid : ids) {
+            var opt = userKeywordRepository.findByUser_UserIdAndKeyword_KeywordId(userId, kid);
+            UserKeyword uk = opt.orElseGet(() -> UserKeyword.builder()
+                    .user(User.builder().userId(userId).build())
+                    .keyword(Keyword.builder().keywordId(kid).build())
+                    .isSelected(true)
+                    .build());
+            uk.setIsSelected(true);
+            userKeywordRepository.save(uk);
         }
-        log.debug("[replaceUserKeywords-direct] END");
     }
 
-    // headers → userId 해석 뒤 기존 메서드 재사용
-    @Transactional
-    public void replaceUserKeywords(String authHeader, String deviceId, List<Integer> keywordIds) {
-        log.debug("[replaceUserKeywords-header] START authHeader='{}', deviceId='{}', keywordIds={}",
-                authHeader, deviceId, keywordIds);
-        String userId = resolveUserId(authHeader, deviceId);
-        log.debug("[replaceUserKeywords-header] resolved userId='{}'", userId);
-        replaceUserKeywords(userId, keywordIds);
-        log.debug("[replaceUserKeywords-header] END");
-    }
-
-    // ===========================================
-    // 선택된 키워드 이름까지 조회
-    // ===========================================
     @Transactional(readOnly = true)
     public List<KeywordGetItemDto> getSelectedKeywordsWithNames(String userId) {
-        log.debug("[getSelectedKeywordsWithNames-direct] userId='{}'", userId);
-
         var selectedList = userKeywordRepository.findByUser_UserIdAndIsSelectedTrue(userId);
-        log.debug("[getSelectedKeywordsWithNames-direct] selectedList.size={}", selectedList == null ? 0 : selectedList.size());
         if (selectedList == null || selectedList.isEmpty()) return List.of();
 
         List<Integer> ids = selectedList.stream()
@@ -304,15 +112,13 @@ public class KeywordService {
                 .filter(Objects::nonNull)
                 .distinct()
                 .toList();
-        log.debug("[getSelectedKeywordsWithNames-direct] ids={}", ids);
 
         if (ids.isEmpty()) return List.of();
 
         List<Keyword> keywords = keywordRepository.findByKeywordIdIn(ids);
         keywords.sort(Comparator.comparing(Keyword::getKeywordId));
-        log.debug("[getSelectedKeywordsWithNames-direct] fetched keywords.size={}", keywords.size());
 
-        List<KeywordGetItemDto> result = keywords.stream()
+        return keywords.stream()
                 .map(k -> KeywordGetItemDto.builder()
                         .keywordId(k.getKeywordId())
                         .name(k.getKeywordName())
@@ -320,45 +126,11 @@ public class KeywordService {
                         .selected(true)
                         .build())
                 .toList();
-        log.debug("[getSelectedKeywordsWithNames-direct] result.size={}", result.size());
-        return result;
-    }
-
-    @Transactional(readOnly = true)
-    public List<KeywordGetItemDto> getSelectedKeywordsWithNames(String authHeader, String deviceId) {
-        log.debug("[getSelectedKeywordsWithNames-header] START authHeader='{}', deviceId='{}'", authHeader, deviceId);
-        String userId = resolveUserId(authHeader, deviceId);
-        List<KeywordGetItemDto> result = getSelectedKeywordsWithNames(userId);
-        log.debug("[getSelectedKeywordsWithNames-header] END userId='{}', result.size={}", userId, result.size());
-        return result;
-    }
-
-    // =========================
-    // 헬퍼
-    // =========================
-    private String extractUserIdOrNull(String authHeader) {
-        log.debug("[extractUserIdOrNull] rawHeader='{}'", authHeader);
-        if (authHeader == null || !authHeader.startsWith("Bearer ")) return null;
-        String token = authHeader.substring("Bearer ".length());
-        String uid = token.isBlank() ? null : "demoUser"; // TODO: JWT 파싱으로 교체
-        log.debug("[extractUserIdOrNull] token='{}' -> uid='{}'", token, uid);
-        return uid;
     }
 
     private String toIconUrl(String imagePath) {
-        log.trace("[toIconUrl] imagePath='{}'", imagePath);
         if (imagePath == null || imagePath.isBlank()) return null;
         if (imagePath.startsWith("http")) return imagePath;
-
-        if (ICON_BASE == null || ICON_BASE.isBlank()) {
-            // 상대경로 반환 (선행 슬래시 보장)
-            String res = imagePath.startsWith("/") ? imagePath : "/" + imagePath;
-            log.trace("[toIconUrl] ICON_BASE blank -> '{}'", res);
-            return res;
-        }
-        boolean needSlash = !ICON_BASE.endsWith("/") && !imagePath.startsWith("/");
-        String res = ICON_BASE + (needSlash ? "/" : "") + imagePath;
-        log.trace("[toIconUrl] joined -> '{}'", res);
-        return res;
+        return ICON_BASE + imagePath;
     }
 }

--- a/src/main/java/com/hackathon_5/Yogiyong_In/service/KeywordService.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/service/KeywordService.java
@@ -1,11 +1,364 @@
 package com.hackathon_5.Yogiyong_In.service;
 
+import com.hackathon_5.Yogiyong_In.DTO.KeywordGetItemDto;
+import com.hackathon_5.Yogiyong_In.DTO.KeywordScrollResDto;
+import com.hackathon_5.Yogiyong_In.domain.Keyword;
+import com.hackathon_5.Yogiyong_In.domain.User;
+import com.hackathon_5.Yogiyong_In.domain.UserKeyword;
+import com.hackathon_5.Yogiyong_In.repository.KeywordRepository;
+import com.hackathon_5.Yogiyong_In.repository.UserKeywordRepository;
+import com.hackathon_5.Yogiyong_In.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.*;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class KeywordService {
+
+    private final KeywordRepository keywordRepository;
+    private final UserKeywordRepository userKeywordRepository;
+    private final UserRepository userRepository;
+
+    // 예: "https://cdn.example.com". 비워두면 toIconUrl에서 상대경로 처리
+    private static final String ICON_BASE = "";
+
+    // =====================================================
+    // 유저 식별: 로그인(JWT) 우선, 아니면 deviceId 기반 게스트
+    // =====================================================
+    private String resolveUserId(String authHeader, String deviceId) {
+        log.debug("[resolveUserId] authHeader='{}', deviceId='{}'", authHeader, deviceId);
+
+        // 1) 로그인 사용자 우선 (TODO: 실제 JWT 파싱으로 교체)
+        String userId = extractUserIdOrNull(authHeader);
+        log.debug("[resolveUserId] extractUserIdOrNull -> {}", userId);
+        if (userId != null) return userId;
+
+        // 2) 비로그인: Device-Id 기반 게스트 생성/보장
+        if (deviceId != null && !deviceId.isBlank()) {
+            log.debug("[resolveUserId] deviceId 존재 -> ensureGuestUser");
+            return ensureGuestUser(deviceId);
+        }
+
+        // 3) 둘 다 없으면 400 성격
+        log.error("[resolveUserId] Authorization/X-Device-Id 둘 다 없음 -> IllegalArgumentException");
+        throw new IllegalArgumentException("Authorization 또는 X-Device-Id 헤더가 필요합니다.");
+    }
+
+    // 게스트 user_id를 20자 이내로 안전 축약: "g:" + sha256(deviceId) 12자리
+    private String compactGuestId(String deviceId) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(deviceId.getBytes(StandardCharsets.UTF_8));
+            String hex = java.util.HexFormat.of().formatHex(digest);
+            String shortHex = hex.substring(0, 12);
+            String result = "g:" + shortHex; // 총 14자
+            log.debug("[compactGuestId] deviceId='{}' -> '{}'", deviceId, result);
+            return result;
+        } catch (Exception e) {
+            String fallback = "g:" + Integer.toHexString(deviceId.hashCode());
+            log.warn("[compactGuestId] SHA-256 실패 -> fallback '{}', reason={}", fallback, e.toString());
+            return fallback;
+        }
+    }
+
+    /**
+     * 게스트 유저를 보장/생성한다.
+     * public + @Transactional 로 둬서 프록시 트랜잭션이 적용되도록 함.
+     */
+    @Transactional
+    public String ensureGuestUser(String deviceId) {
+        log.debug("[ensureGuestUser] START deviceId='{}'", deviceId);
+        String userId = "guest:" + deviceId;
+        if (userId.length() > 20) {
+            userId = compactGuestId(deviceId); // 20자 이내 보장
+        }
+        if (userRepository.existsById(userId)) {
+            log.debug("[ensureGuestUser] 이미 존재 -> userId='{}'", userId);
+            return userId;
+        }
+
+        String base = "guest_" + Math.abs(deviceId.hashCode());
+        String nick = base.substring(0, Math.min(20, base.length()));
+
+        // 닉네임 UNIQUE 충돌에 대비해 최대 5회 재시도
+        for (int i = 0; i < 5; i++) {
+            try {
+                User user = User.builder()
+                        .userId(userId)
+                        .password(UUID.randomUUID().toString()) // NOT NULL 충족 + 의미 없는 랜덤 문자열
+                        .nickname(nick)
+                        .birthYear(null)
+                        .build();
+                userRepository.saveAndFlush(user);
+                log.info("[ensureGuestUser] 게스트 생성 성공 userId='{}', nickname='{}'", userId, nick);
+                return userId;
+            } catch (DataIntegrityViolationException dup) {
+                log.warn("[ensureGuestUser] 닉네임 충돌 재시도 idx={}, base='{}'", i, base);
+                String suffix = "_" + i;
+                int cut = Math.max(0, 20 - suffix.length());
+                nick = base.substring(0, Math.min(cut, base.length())) + suffix;
+            }
+        }
+
+        // 최후의 수단: 랜덤 닉네임
+        String rndNick = UUID.randomUUID().toString().replace("-", "").substring(0, 20);
+        User user = User.builder()
+                .userId(userId)
+                .password(UUID.randomUUID().toString())
+                .nickname(rndNick)
+                .birthYear(null)
+                .build();
+        userRepository.save(user);
+        log.info("[ensureGuestUser] 랜덤 닉네임으로 최종 생성 userId='{}', nickname='{}'", userId, rndNick);
+        return userId;
+    }
+
+    // ===========================================
+    // [기존 유지] authHeader만 받는 버전 (로그인 전제)
+    // ===========================================
+    @Transactional(readOnly = true)
+    public KeywordScrollResDto getKeywordsScroll(Integer cursor, int size, boolean includeSelected, String authHeader) {
+        log.debug("[getKeywordsScroll-basic] cursor={}, size={}, includeSelected={}, authHeader='{}'",
+                cursor, size, includeSelected, authHeader);
+
+        int s = size <= 0 ? 30 : Math.min(size, 100);
+
+        List<Keyword> slice = keywordRepository.findScroll(cursor, PageRequest.of(0, s + 1));
+        boolean hasNext = slice.size() > s;
+        if (hasNext) slice = slice.subList(0, s);
+        log.debug("[getKeywordsScroll-basic] slice.size={}, hasNext={}", slice.size(), hasNext);
+
+        String userId = extractUserIdOrNull(authHeader);
+        log.debug("[getKeywordsScroll-basic] resolved userId='{}'", userId);
+
+        Set<Integer> selectedIds = Collections.emptySet();
+
+        if (includeSelected && userId != null && !slice.isEmpty()) {
+            List<Integer> ids = slice.stream().map(Keyword::getKeywordId).toList();
+            log.debug("[getKeywordsScroll-basic] includeSelected ids={}", ids);
+            selectedIds = userKeywordRepository.findSelectedIn(userId, ids).stream()
+                    .map(uk -> uk.getKeyword().getKeywordId())
+                    .collect(Collectors.toSet());
+            log.debug("[getKeywordsScroll-basic] selectedIds={}", selectedIds);
+        }
+
+        final Set<Integer> finalSelectedIds = selectedIds;
+
+        List<KeywordGetItemDto> items = slice.stream()
+                .map(k -> KeywordGetItemDto.builder()
+                        .keywordId(k.getKeywordId())
+                        .name(k.getKeywordName())
+                        .iconUrl(toIconUrl(k.getImagePath()))
+                        .selected(includeSelected && userId != null
+                                ? finalSelectedIds.contains(k.getKeywordId())
+                                : null)
+                        .build())
+                .toList();
+
+        Integer nextCursor = items.isEmpty() ? null : items.get(items.size() - 1).getKeywordId();
+        log.debug("[getKeywordsScroll-basic] items={}, nextCursor={}", items.size(), nextCursor);
+
+        return KeywordScrollResDto.builder()
+                .items(items)
+                .nextCursor(nextCursor)
+                .hasNext(hasNext)
+                .build();
+    }
+
+    // ===================================================
+    // [개선] deviceId 포함 버전: includeSelected일 때만 게스트 보장(Lazy)
+    // ===================================================
+    @Transactional(readOnly = true)
+    public KeywordScrollResDto getKeywordsScroll(
+            Integer cursor, int size, boolean includeSelected,
+            String authHeader, String deviceId
+    ) {
+        log.debug("[getKeywordsScroll-extended] cursor={}, size={}, includeSelected={}, authHeader='{}', deviceId='{}'",
+                cursor, size, includeSelected, authHeader, deviceId);
+
+        final String uid;
+        if (includeSelected) {
+            // 선택표시 계산이 필요할 때에만 userId 해석/게스트 보장
+            String tmp;
+            try {
+                tmp = resolveUserId(authHeader, deviceId);
+            } catch (IllegalArgumentException e) {
+                log.warn("[getKeywordsScroll-extended] userId 해석 실패(includeSelected=true) -> 선택표시 미표시, reason={}", e.getMessage());
+                tmp = null; // 선택표시 불가
+            }
+            uid = tmp;
+        } else {
+            uid = null; // 조회만 할 때는 게스트 생성 안 함
+        }
+        log.debug("[getKeywordsScroll-extended] resolved uid='{}'", uid);
+
+        int s = size <= 0 ? 30 : Math.min(size, 100);
+
+        List<Keyword> slice = keywordRepository.findScroll(cursor, PageRequest.of(0, s + 1));
+        boolean hasNext = slice.size() > s;
+        if (hasNext) slice = slice.subList(0, s);
+        log.debug("[getKeywordsScroll-extended] slice.size={}, hasNext={}", slice.size(), hasNext);
+
+        Set<Integer> selectedIds = Collections.emptySet();
+        if (includeSelected && uid != null && !slice.isEmpty()) {
+            List<Integer> ids = slice.stream().map(Keyword::getKeywordId).toList();
+            log.debug("[getKeywordsScroll-extended] includeSelected ids={}", ids);
+            selectedIds = userKeywordRepository.findSelectedIn(uid, ids).stream()
+                    .map(uk -> uk.getKeyword().getKeywordId())
+                    .collect(Collectors.toSet());
+            log.debug("[getKeywordsScroll-extended] selectedIds={}", selectedIds);
+        }
+        final Set<Integer> finalSelectedIds = selectedIds;
+
+        List<KeywordGetItemDto> items = slice.stream()
+                .map(k -> KeywordGetItemDto.builder()
+                        .keywordId(k.getKeywordId())
+                        .name(k.getKeywordName())
+                        .iconUrl(toIconUrl(k.getImagePath()))
+                        .selected(includeSelected && uid != null
+                                ? finalSelectedIds.contains(k.getKeywordId())
+                                : null)
+                        .build())
+                .toList();
+
+        Integer nextCursor = items.isEmpty() ? null : items.get(items.size() - 1).getKeywordId();
+        log.debug("[getKeywordsScroll-extended] items={}, nextCursor={}", items.size(), nextCursor);
+
+        return KeywordScrollResDto.builder()
+                .items(items)
+                .nextCursor(nextCursor)
+                .hasNext(hasNext)
+                .build();
+    }
+
+    // ===========================================
+    // 선택 교체(업서트): 전체 false → 전달된 것만 true
+    // ===========================================
+    @Transactional
+    public void replaceUserKeywords(String userId, List<Integer> keywordIds) {
+        log.debug("[replaceUserKeywords-direct] START userId='{}', keywordIds={}", userId, keywordIds);
+
+        // 전체 해제
+        int updated = userKeywordRepository.clearSelections(userId);
+        log.debug("[replaceUserKeywords-direct] clearSelections updatedRows={}", updated);
+
+        if (keywordIds == null || keywordIds.isEmpty()) {
+            log.debug("[replaceUserKeywords-direct] keywordIds 비어있음 -> END");
+            return;
+        }
+
+        // 전달된 것만 선택 true로 업서트
+        for (Integer kid : keywordIds) {
+            log.debug("[replaceUserKeywords-direct] upsert keywordId={}", kid);
+            var existing = userKeywordRepository.findByUser_UserIdAndKeyword_KeywordId(userId, kid);
+            if (existing.isPresent()) {
+                log.trace("[replaceUserKeywords-direct] 기존 존재 -> set isSelected=true & save");
+                existing.get().setIsSelected(true);
+                userKeywordRepository.save(existing.get());
+            } else {
+                log.trace("[replaceUserKeywords-direct] 신규 생성 -> save");
+                UserKeyword uk = new UserKeyword();
+                uk.setUser(User.builder().userId(userId).build());
+                uk.setKeyword(Keyword.builder().keywordId(kid).build());
+                uk.setIsSelected(true);
+                userKeywordRepository.save(uk);
+            }
+        }
+        log.debug("[replaceUserKeywords-direct] END");
+    }
+
+    // headers → userId 해석 뒤 기존 메서드 재사용
+    @Transactional
+    public void replaceUserKeywords(String authHeader, String deviceId, List<Integer> keywordIds) {
+        log.debug("[replaceUserKeywords-header] START authHeader='{}', deviceId='{}', keywordIds={}",
+                authHeader, deviceId, keywordIds);
+        String userId = resolveUserId(authHeader, deviceId);
+        log.debug("[replaceUserKeywords-header] resolved userId='{}'", userId);
+        replaceUserKeywords(userId, keywordIds);
+        log.debug("[replaceUserKeywords-header] END");
+    }
+
+    // ===========================================
+    // 선택된 키워드 이름까지 조회
+    // ===========================================
+    @Transactional(readOnly = true)
+    public List<KeywordGetItemDto> getSelectedKeywordsWithNames(String userId) {
+        log.debug("[getSelectedKeywordsWithNames-direct] userId='{}'", userId);
+
+        var selectedList = userKeywordRepository.findByUser_UserIdAndIsSelectedTrue(userId);
+        log.debug("[getSelectedKeywordsWithNames-direct] selectedList.size={}", selectedList == null ? 0 : selectedList.size());
+        if (selectedList == null || selectedList.isEmpty()) return List.of();
+
+        List<Integer> ids = selectedList.stream()
+                .map(uk -> uk.getKeyword().getKeywordId())
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        log.debug("[getSelectedKeywordsWithNames-direct] ids={}", ids);
+
+        if (ids.isEmpty()) return List.of();
+
+        List<Keyword> keywords = keywordRepository.findByKeywordIdIn(ids);
+        keywords.sort(Comparator.comparing(Keyword::getKeywordId));
+        log.debug("[getSelectedKeywordsWithNames-direct] fetched keywords.size={}", keywords.size());
+
+        List<KeywordGetItemDto> result = keywords.stream()
+                .map(k -> KeywordGetItemDto.builder()
+                        .keywordId(k.getKeywordId())
+                        .name(k.getKeywordName())
+                        .iconUrl(toIconUrl(k.getImagePath()))
+                        .selected(true)
+                        .build())
+                .toList();
+        log.debug("[getSelectedKeywordsWithNames-direct] result.size={}", result.size());
+        return result;
+    }
+
+    @Transactional(readOnly = true)
+    public List<KeywordGetItemDto> getSelectedKeywordsWithNames(String authHeader, String deviceId) {
+        log.debug("[getSelectedKeywordsWithNames-header] START authHeader='{}', deviceId='{}'", authHeader, deviceId);
+        String userId = resolveUserId(authHeader, deviceId);
+        List<KeywordGetItemDto> result = getSelectedKeywordsWithNames(userId);
+        log.debug("[getSelectedKeywordsWithNames-header] END userId='{}', result.size={}", userId, result.size());
+        return result;
+    }
+
+    // =========================
+    // 헬퍼
+    // =========================
+    private String extractUserIdOrNull(String authHeader) {
+        log.debug("[extractUserIdOrNull] rawHeader='{}'", authHeader);
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) return null;
+        String token = authHeader.substring("Bearer ".length());
+        String uid = token.isBlank() ? null : "demoUser"; // TODO: JWT 파싱으로 교체
+        log.debug("[extractUserIdOrNull] token='{}' -> uid='{}'", token, uid);
+        return uid;
+    }
+
+    private String toIconUrl(String imagePath) {
+        log.trace("[toIconUrl] imagePath='{}'", imagePath);
+        if (imagePath == null || imagePath.isBlank()) return null;
+        if (imagePath.startsWith("http")) return imagePath;
+
+        if (ICON_BASE == null || ICON_BASE.isBlank()) {
+            // 상대경로 반환 (선행 슬래시 보장)
+            String res = imagePath.startsWith("/") ? imagePath : "/" + imagePath;
+            log.trace("[toIconUrl] ICON_BASE blank -> '{}'", res);
+            return res;
+        }
+        boolean needSlash = !ICON_BASE.endsWith("/") && !imagePath.startsWith("/");
+        String res = ICON_BASE + (needSlash ? "/" : "") + imagePath;
+        log.trace("[toIconUrl] joined -> '{}'", res);
+        return res;
+    }
 }


### PR DESCRIPTION
### 변경 내용
- 키워드 조회 API(`/api/keywords`) **로그인 필수**로 변경
- Swagger 문서: `@SecurityRequirement(bearerAuth)` 유지, Authorization 헤더는 Authorize 버튼 사용
- 서비스/레포지토리 로직 정리 (선택 여부 포함 플래그 처리)

### 변경 사유
- 로그인된 사용자만 가능하도록

### 테스트 방법
1. Swagger에서 Authorize에 유효 토큰 입력
2. `GET /api/keywords`
   - 토큰 없으면 `401`
   - 토큰 있으면 정상 조회 (includeSelected=true 시 선택여부 필드 포함)
3. `PUT /api/me/selected-keywords` 정상 저장 확인


