### PR TITLE
[ADD] AI 축제 추천 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,48 +1,55 @@
-HELP.md
-.gradle
-build/
-!gradle/wrapper/gradle-wrapper.jar
-!**/src/main/**/build/
-!**/src/test/**/build/
+# ===== Docs (원하면 주석 해제해서 무시) =====
+# HELP.md
 
-### STS ###
+# ===== Gradle =====
+.gradle/
+**/build/
+!gradle/wrapper/gradle-wrapper.jar
+!gradle/wrapper/gradle-wrapper.properties
+
+# ===== IntelliJ IDEA =====
+.idea/
+*.iml
+*.iws
+*.ipr
+**/out/
+
+# ===== STS / Eclipse =====
 .apt_generated
 .classpath
 .factorypath
 .project
-.settings
+.settings/
 .springBeans
 .sts4-cache
-bin/
-!**/src/main/**/bin/
-!**/src/test/**/bin/
+**/bin/
 
-### IntelliJ IDEA ###
-.idea
-*.iws
-*.iml
-*.ipr
-out/
-!**/src/main/**/out/
-!**/src/test/**/out/
-
-### NetBeans ###
+# ===== NetBeans =====
 /nbproject/private/
 /nbbuild/
 /dist/
 /nbdist/
 /.nb-gradle/
 
-### VS Code ###
+# ===== VS Code =====
 .vscode/
 
-# src/main/resources/application.yml 파일 무시
-/src/main/resources/application.yml
+# ===== OS / Logs =====
+.DS_Store
+Thumbs.db
+*.log
+logs/
+hs_err_pid*.log
 
-# Spring Boot configuration
+# ===== Env files =====
+.env
+.env.*
+
+# ===== Spring Boot configuration (민감정보 커밋 금지) =====
 src/main/resources/application.yml
 src/main/resources/application-*.yml
 src/main/resources/application.properties
 src/main/resources/application-*.properties
 
-
+# 예시 설정 파일은 커밋 허용 (팀 공유용)
+!src/main/resources/application-example.yml

--- a/src/main/java/com/hackathon_5/Yogiyong_In/DTO/AiRecommend/FestivalRecommendGetItemDto.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/DTO/AiRecommend/FestivalRecommendGetItemDto.java
@@ -1,0 +1,16 @@
+package com.hackathon_5.Yogiyong_In.DTO.AiRecommend;
+
+import lombok.*;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+public class FestivalRecommendGetItemDto {
+    // DB 컬럼명과 1:1로 대응 (변수명은 자바 컨벤션)
+    private Integer festivalId;     // festivals.festival_id
+    private String  festivalName;   // festivals.festival_name
+    private String  festivalDesc;   // festivals.festival_desc
+    private String  festivalStart;  // festivals.festival_start (ISO 문자열)
+    private String  festivalEnd;    // festivals.festival_end   (ISO 문자열)
+    private String  festivalLoca;   // festivals.festival_loca
+    private String  imagePath;      // festivals.image_path
+}

--- a/src/main/java/com/hackathon_5/Yogiyong_In/DTO/AiRecommend/FestivalRecommendGetResDto.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/DTO/AiRecommend/FestivalRecommendGetResDto.java
@@ -1,0 +1,11 @@
+package com.hackathon_5.Yogiyong_In.DTO.AiRecommend;
+
+import lombok.*;
+import java.util.List;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+public class FestivalRecommendGetResDto {
+    private List<FestivalRecommendGetItemDto> items; // 추천 축제 목록
+    private int totalCount;                           // 총 개수
+}

--- a/src/main/java/com/hackathon_5/Yogiyong_In/controller/FestivalRecommendController.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/controller/FestivalRecommendController.java
@@ -1,0 +1,46 @@
+package com.hackathon_5.Yogiyong_In.controller;
+
+import com.hackathon_5.Yogiyong_In.DTO.ApiResponse;
+import com.hackathon_5.Yogiyong_In.DTO.AiRecommend.FestivalRecommendGetResDto;
+import com.hackathon_5.Yogiyong_In.service.FestivalRecommendService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/festivals")
+public class FestivalRecommendController {
+
+    private final FestivalRecommendService recommendService;
+
+    @Operation(
+            summary = "AI 축제 추천",
+            description = "로그인한 사용자의 선택 키워드를 기반으로 축제 ID를 AI가 선택하고, 해당 축제 정보를 반환합니다. (reason 제외)",
+            security = { @SecurityRequirement(name = "bearerAuth") }
+    )
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/recommend")
+    public ResponseEntity<ApiResponse<FestivalRecommendGetResDto>> recommend(
+            Authentication authentication,
+            @RequestParam(name = "limit", required = false, defaultValue = "5") Integer limit
+    ) {
+        String userId = authentication.getName(); // JwtAuthenticationFilter에서 세팅됨
+        var result = recommendService.recommend(userId, limit);
+
+        var body = ApiResponse.ok(result.data()); // <-- data만 바디에
+
+        // message가 있으면 헤더에 포함 (프론트에서 선택적으로 표시)
+        if (result.message() == null || result.message().isBlank()) {
+            return ResponseEntity.ok(body);
+        } else {
+            return ResponseEntity.ok()
+                    .header("X-Info-Message", result.message())
+                    .body(body);
+        }
+    }
+}

--- a/src/main/java/com/hackathon_5/Yogiyong_In/service/FestivalRecommendResult.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/service/FestivalRecommendResult.java
@@ -1,0 +1,8 @@
+package com.hackathon_5.Yogiyong_In.service;
+
+import com.hackathon_5.Yogiyong_In.DTO.AiRecommend.FestivalRecommendGetResDto;
+
+public record FestivalRecommendResult(
+        FestivalRecommendGetResDto data,
+        String message // null이면 메시지 없댜
+) {}

--- a/src/main/java/com/hackathon_5/Yogiyong_In/service/FestivalRecommendService.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/service/FestivalRecommendService.java
@@ -1,0 +1,197 @@
+package com.hackathon_5.Yogiyong_In.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.genai.Client;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.GenerateContentResponse;
+import com.hackathon_5.Yogiyong_In.DTO.AiRecommend.FestivalRecommendGetItemDto;
+import com.hackathon_5.Yogiyong_In.DTO.AiRecommend.FestivalRecommendGetResDto;
+import com.hackathon_5.Yogiyong_In.domain.Festival;
+import com.hackathon_5.Yogiyong_In.repository.FestivalRepository;
+import com.hackathon_5.Yogiyong_In.repository.UserKeywordRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FestivalRecommendService {
+    private static final String MODEL = "gemini-2.5-flash-lite";
+    private static final int DEFAULT_TOP_N = 5;
+    private static final int CATALOG_MAX = 120; // 토큰 보호 상한
+    private static final int DESC_TRIM = 300;
+    private static final int PROMPT_DESC_TRIM = 160;
+
+    private final UserKeywordRepository userKeywordRepository;
+    private final FestivalRepository festivalRepository;
+    private final Client geminiClient; // GeminiClientConfig 에서 주입
+
+    private final ObjectMapper om = new ObjectMapper();
+
+    @Transactional(readOnly = true)
+    public FestivalRecommendResult recommend(String userId, Integer limit) {
+
+        // 1) 사용자 선택 키워드
+        var keywordNames = userKeywordRepository.findByUser_UserIdAndIsSelectedTrue(userId).stream()
+                .map(uk -> uk.getKeyword().getKeywordName())
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
+                .distinct()
+                .toList();
+
+        if (keywordNames.isEmpty()) {
+            log.debug("[AI-RECO] userId={} has no selected keywords", userId);
+            return new FestivalRecommendResult(
+                    FestivalRecommendGetResDto.builder().items(List.of()).totalCount(0).build(),
+                    "선택된 키워드가 없어 추천 결과가 없습니다."
+            );
+        }
+
+        // 2) 축제 카탈로그
+        var all = festivalRepository.findAll();
+        if (all.isEmpty()) {
+            log.debug("[AI-RECO] No festivals in catalog");
+            return new FestivalRecommendResult(
+                    FestivalRecommendGetResDto.builder().items(List.of()).totalCount(0).build(),
+                    "등록된 축제 데이터가 없어 추천할 수 없습니다."
+            );
+        }
+        var catalog = all.stream().limit(CATALOG_MAX).toList();
+
+        // 3) 프롬프트
+        int topN = (limit == null || limit <= 0) ? DEFAULT_TOP_N : limit;
+        String prompt = buildPromptIdsOnly(keywordNames, catalog, topN);
+
+        // 4) Gemini 호출
+        String aiText = callGemini(prompt);
+        if (aiText.isBlank()) {
+            log.warn("[AI-RECO] Empty response from Gemini");
+            return new FestivalRecommendResult(
+                    FestivalRecommendGetResDto.builder().items(List.of()).totalCount(0).build(),
+                    "AI 응답이 비어 있어 추천 결과가 없습니다."
+            );
+        }
+
+        // 5) 응답 파싱
+        List<Integer> ids = parseFestivalIds(aiText);
+        if (ids.isEmpty()) {
+            log.warn("[AI-RECO] No ids parsed from Gemini response: {}", aiText);
+            return new FestivalRecommendResult(
+                    FestivalRecommendGetResDto.builder().items(List.of()).totalCount(0).build(),
+                    "AI 응답을 해석하지 못해 추천 결과가 없습니다."
+            );
+        }
+
+        // 6) 매핑 → DTO
+        Map<Integer, Festival> byId = catalog.stream()
+                .collect(Collectors.toMap(Festival::getFestivalId, f -> f));
+
+        var items = ids.stream()
+                .map(byId::get)
+                .filter(Objects::nonNull)
+                .map(this::toItemDto)
+                .toList();
+
+        var data = FestivalRecommendGetResDto.builder()
+                .items(items)
+                .totalCount(items.size())
+                .build();
+
+        // 결과가 0개라면 안내 메시지
+        String msg = items.isEmpty() ? "조건에 맞는 추천 축제가 없습니다." : null;
+        return new FestivalRecommendResult(data, msg);
+    }
+
+    private FestivalRecommendGetItemDto toItemDto(Festival f) {
+        return FestivalRecommendGetItemDto.builder()
+                .festivalId(f.getFestivalId())
+                .festivalName(f.getFestivalName())
+                .festivalDesc(trim(f.getFestivalDesc(), DESC_TRIM))
+                .festivalStart(f.getFestivalStart() != null ? f.getFestivalStart().toString() : null)
+                .festivalEnd(f.getFestivalEnd() != null ? f.getFestivalEnd().toString() : null)
+                .festivalLoca(f.getFestivalLoca())
+                .imagePath(f.getImagePath())
+                .build();
+    }
+
+    private String buildPromptIdsOnly(List<String> kws, List<Festival> catalog, int topN) {
+        String kw = String.join(", ", kws);
+
+        StringBuilder sb = new StringBuilder();
+        for (Festival f : catalog) {
+            sb.append(String.format(
+                    "- festival_id: %d | name: %s | loca: %s | start: %s | end: %s | desc: %s%n",
+                    f.getFestivalId(),
+                    ns(f.getFestivalName()),
+                    ns(f.getFestivalLoca()),
+                    f.getFestivalStart() != null ? f.getFestivalStart().toString() : "null",
+                    f.getFestivalEnd() != null ? f.getFestivalEnd().toString() : "null",
+                    trim(ns(f.getFestivalDesc()), PROMPT_DESC_TRIM)
+            ));
+        }
+
+        return """
+               사용자 선택 키워드: [%s]
+               아래 '축제 카탈로그'에서 키워드와 가장 잘 맞는 축제의 festival_id를 상위 %d개 고르시오.
+
+               **출력 형식은 숫자만 포함된 JSON 배열**만 허용한다. 예: [12, 7, 3]
+               마크다운/설명문/코드펜스 금지. 배열 외 텍스트 출력 금지.
+
+               축제 카탈로그:
+               %s
+               """.formatted(kw, topN, sb);
+    }
+
+    private String callGemini(String prompt) {
+        GenerateContentConfig config = GenerateContentConfig.builder()
+                .candidateCount(1)
+                .maxOutputTokens(200) // JSON 배열만 필요하므로 작게
+                .build();
+
+        GenerateContentResponse resp = geminiClient.models.generateContent(
+                MODEL,
+                prompt,
+                config
+        );
+
+        String result = resp.text();
+        return (result == null) ? "" : result.trim();
+    }
+
+    private List<Integer> parseFestivalIds(String aiText) {
+        if (aiText == null || aiText.isBlank()) return List.of();
+
+        Pattern p = Pattern.compile("\\[\\s*(?:\\d+\\s*(?:,\\s*\\d+\\s*)*)?\\]");
+        Matcher m = p.matcher(aiText);
+        String json = m.find() ? m.group() : aiText;
+
+        try {
+            return om.readValue(json, new TypeReference<List<Integer>>() {});
+        } catch (Exception primary) {
+            try {
+                record IdObj(Integer festival_id) {}
+                List<IdObj> objs = om.readValue(json, new TypeReference<List<IdObj>>() {});
+                return objs.stream().map(IdObj::festival_id).filter(Objects::nonNull).toList();
+            } catch (Exception secondary) {
+                log.warn("Gemini 응답 파싱 실패: {}", secondary.getMessage());
+                return List.of();
+            }
+        }
+    }
+
+    private static String ns(String s){ return s == null ? "" : s; }
+    private static String trim(String s, int max){
+        if (s == null) return null;
+        String t = s.replaceAll("\\s+"," ").trim();
+        return t.length() <= max ? t : t.substring(0, max) + "…";
+    }
+}


### PR DESCRIPTION


**Summary**
사용자 선택 키워드 기반으로 Gemini가 `festival_id`를 추천하고, 해당 ID로 축제 정보를 반환하는 API 추가.

**Endpoint**

* `GET /api/festivals/recommend` (JWT)
* Query: `limit` (optional, default=5)

**Response**

* Body: `ApiResponse<FestivalRecommendGetResDto>`
* Header: `X-Info-Message` (키워드/데이터 없음 등 안내)

**Changes**

* Controller/Service/DTO 추가 (`FestivalRecommendResult` 포함)

**How to test**

* Swagger `/docs` → Authorize(Bearer) → `GET /api/festivals/recommend`

**Notes**

* Gemini API Key 필요: 환경변수 `GOOGLE_API_KEY`(or `GEMINI_API_KEY`) 사용 권장
* 키 미설정 시 서버 부팅 실패 → 실행 전 반드시 설정
* 설정 파일(.yml/.properties) 커밋 금지 (예시는 `application-example.yml`)
