### PR TITLE
[ãADD]기ëì:월캘린더 월별 표시용°

### DIFF
--- a/src/main/java/com/hackathon_5/Yogiyong_In/DTO/Bookmark/BookmarkListResDto.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/DTO/Bookmark/BookmarkListResDto.java
@@ -1,9 +1,9 @@
 package com.hackathon_5.Yogiyong_In.DTO.Bookmark;
 
-import com.hackathon_5.Yogiyong_In.domain.Festival;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Getter @AllArgsConstructor @Builder

--- a/src/main/java/com/hackathon_5/Yogiyong_In/DTO/Festival/FestivalCalendarDto.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/DTO/Festival/FestivalCalendarDto.java
@@ -1,0 +1,37 @@
+package com.hackathon_5.Yogiyong_In.DTO.Festival;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FestivalCalendarDto {
+
+    private Integer festivalId;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate festivalStart;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate festivalEnd;
+
+    // 현재 달 기준 표시 시작일 (ex: 7월 조회 → 7/30)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate displayStart;
+
+    // 현재 달 기준 표시 종료일 (ex: 7월 조회 → 7/31)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate displayEnd;
+
+    // JPQL에서 사용하는 생성자 (festivalId, festivalStart, festivalEnd)
+    public FestivalCalendarDto(Integer festivalId, LocalDate festivalStart, LocalDate festivalEnd) {
+        this.festivalId = festivalId;
+        this.festivalStart = festivalStart;
+        this.festivalEnd = festivalEnd;
+    }
+}

--- a/src/main/java/com/hackathon_5/Yogiyong_In/DTO/Festival/FestivalInfoReqDto.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/DTO/Festival/FestivalInfoReqDto.java
@@ -1,17 +1,20 @@
 package com.hackathon_5.Yogiyong_In.DTO.Festival;
 
-
 import lombok.*;
+import java.time.LocalDate;
 
-@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class FestivalInfoReqDto {
     private Integer festivalId;
     private String festivalName;
     private String festivalDesc;
-    private String festivalStart;
-    private String festivalEnd;
+    private LocalDate festivalStart;  // ← String → LocalDate
+    private LocalDate festivalEnd;    // ← String → LocalDate
     private String festivalLoca;
     private String imagePath;
     private String aiReview;
 }
-

--- a/src/main/java/com/hackathon_5/Yogiyong_In/DTO/Festival/FestivalInfoResDto.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/DTO/Festival/FestivalInfoResDto.java
@@ -1,17 +1,20 @@
 package com.hackathon_5.Yogiyong_In.DTO.Festival;
 
-
 import lombok.*;
+import java.time.LocalDate;
 
-@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class FestivalInfoResDto {
     private Integer festivalId;
     private String festivalName;
     private String festivalDesc;
-    private String festivalStart;
-    private String festivalEnd;
+    private LocalDate festivalStart;  // ← String → LocalDate
+    private LocalDate festivalEnd;    // ← String → LocalDate
     private String festivalLoca;
     private String imagePath;
     private String aiReview;
 }
-

--- a/src/main/java/com/hackathon_5/Yogiyong_In/controller/CalendarController.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/controller/CalendarController.java
@@ -1,11 +1,16 @@
 package com.hackathon_5.Yogiyong_In.controller;
 
 import com.hackathon_5.Yogiyong_In.DTO.Festival.FestivalInfoResDto;
+import com.hackathon_5.Yogiyong_In.DTO.Festival.FestivalCalendarDto;
+import com.hackathon_5.Yogiyong_In.DTO.ApiResponse;
 import com.hackathon_5.Yogiyong_In.service.CalendarService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -33,5 +38,20 @@ public class CalendarController {
             @RequestParam int month,
             @RequestParam int date) {
         return ResponseEntity.ok(calendarService.getFestivalsByDate(year, month, date));
+    }
+
+    @Operation(summary = "월별 축제 조회(달력용)")
+    @GetMapping("/by-month")
+    public ResponseEntity<ApiResponse<List<FestivalCalendarDto>>> byMonth(
+            @RequestParam int year, @RequestParam int month) {
+        return ResponseEntity.ok(ApiResponse.ok(calendarService.getByMonth(year, month)));
+    }
+
+    @Operation(summary = "기간 겹침 축제 조회(달력용)")
+    @GetMapping("/range")
+    public ResponseEntity<ApiResponse<List<FestivalCalendarDto>>> byRange(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end) {
+        return ResponseEntity.ok(ApiResponse.ok(calendarService.getRange(start, end)));
     }
 }

--- a/src/main/java/com/hackathon_5/Yogiyong_In/domain/Festival.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/domain/Festival.java
@@ -2,6 +2,7 @@ package com.hackathon_5.Yogiyong_In.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import java.time.LocalDate;
 
 @Entity
 @Table(name = "festivals")
@@ -23,10 +24,10 @@ public class Festival {
     private String festivalDesc;
 
     @Column(name = "festival_start")
-    private String festivalStart;
+    private LocalDate festivalStart;
 
     @Column(name = "festival_end")
-    private String festivalEnd;
+    private LocalDate festivalEnd;
 
     @Column(name = "festival_loca", length = 50)
     private String festivalLoca;
@@ -34,6 +35,7 @@ public class Festival {
     @Column(name = "image_path", length = 255)
     private String imagePath;
 
-    @Column(name = "ai_review", columnDefinition = "TEXT")
-    private String aiReview;
+    // DDL/ERD에 없음: 필요 시 DTO/별도 테이블로 처리해야할듯여
+    // @Transient
+    // private String aiReview;
 }

--- a/src/main/java/com/hackathon_5/Yogiyong_In/repository/FestivalRepository.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/repository/FestivalRepository.java
@@ -1,14 +1,35 @@
 package com.hackathon_5.Yogiyong_In.repository;
 
 import com.hackathon_5.Yogiyong_In.domain.Festival;
+import com.hackathon_5.Yogiyong_In.DTO.Festival.FestivalCalendarDto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Repository
 public interface FestivalRepository extends JpaRepository<Festival, Integer> {
+
+    // 기존 메서드 ｓｔｒｉｎｇ 사용하면 데이터타입 안맞아서 이 부분 수정함
     List<Festival> findByFestivalStartLessThanEqualAndFestivalEndGreaterThanEqual(
-            String startDate, String endDate
+            LocalDate startDate, LocalDate endDate
+    );
+
+    // 커스텀 JPQL
+    @Query("""
+      select new com.hackathon_5.Yogiyong_In.DTO.Festival.FestivalCalendarDto(
+         f.festivalId, f.festivalStart, f.festivalEnd
+      )
+      from Festival f
+      where f.festivalStart <= :end
+        and f.festivalEnd   >= :start
+      order by f.festivalStart asc
+    """)
+    List<FestivalCalendarDto> findForCalendar(
+            @Param("start") LocalDate start,
+            @Param("end")   LocalDate end
     );
 }


### PR DESCRIPTION
## 개요
- 월별 축제 조회 API 추가
- 달력 화면에 표시할 수 있도록 `displayStart`, `displayEnd` 값 계산 로직 반영

## 주요 변경 사항
- CalendarService
  - getByMonth(year, month): 해당 월 시작일~마지막일 기준으로 축제 조회
  - displayStart = max(festivalStart, monthStart)
  - displayEnd   = min(festivalEnd, monthEnd)
- FestivalCalendarDto
  - DTO에 displayStart, displayEnd 필드 추가 및 응답에 반영
- CalendarController
  - GET `/api/calendar/by-month` 엔드포인트 추가

## 테스트
- Swagger `/api/calendar/by-month?year=2025&month=8` 요청 시 정상 동작 확인
- 기간이 월을 넘어가는 축제도 displayStart/displayEnd 보정값으로 표시됨
- 정상 동작 예시 응답:
```json
{
  "success": true,
  "data": [
    {
      "festivalId": 3,
      "festivalStart": "2025-07-30",
      "festivalEnd": "2025-08-05",
      "displayStart": "2025-08-01",
      "displayEnd": "2025-08-05"
    },
    {
      "festivalId": 4,
      "festivalStart": "2025-08-10",
      "festivalEnd": "2025-09-02",
      "displayStart": "2025-08-10",
      "displayEnd": "2025-08-31"
    }
  ]
}
