### PR TITLE
feat: 북마크 ID 전용 API 추가

### DIFF
--- a/src/main/java/com/hackathon_5/Yogiyong_In/controller/BookmarkController.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/controller/BookmarkController.java
@@ -3,6 +3,8 @@ package com.hackathon_5.Yogiyong_In.controller;
 import com.hackathon_5.Yogiyong_In.dto.ApiResponse;
 import com.hackathon_5.Yogiyong_In.dto.Bookmark.BookmarkCreateReqDto;
 import com.hackathon_5.Yogiyong_In.dto.Bookmark.BookmarkCreateResDto;
+// [ADD] 새로 만든 DTO import 추가
+import com.hackathon_5.Yogiyong_In.dto.Bookmark.BookmarkIdListResDto;
 import com.hackathon_5.Yogiyong_In.dto.Bookmark.BookmarkListResDto;
 import com.hackathon_5.Yogiyong_In.config.JwtTokenProvider;
 import com.hackathon_5.Yogiyong_In.service.BookmarkService;
@@ -12,8 +14,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
@@ -57,6 +57,26 @@ public class BookmarkController {
         }
     }
 
+    // [ADD] 작성하신 새 메소드를 여기에 추가
+    @Operation(
+            summary = "마이페이지 북마크 ID 모아보기",
+            description = "내가 저장한 북마크의 축제 ID 목록만 반환합니다."
+    )
+    @GetMapping("/mypage/bookmarks/ids")
+    public ApiResponse<BookmarkIdListResDto> getMyBookmarkIds(HttpServletRequest request) {
+        String token = AuthUtils.resolveAccessToken(request);
+        if (token == null) return ApiResponse.fail("인증 토큰이 없습니다.");
+        String userId = jwtTokenProvider.getSubject(token);
+
+        try {
+            // 서비스 메소드 이름은 getMyBookmarks -> getMyBookmarkFestivalIds
+            return ApiResponse.ok(bookmarkService.getMyBookmarkFestivalIds(userId), "북마크 ID 목록");
+        } catch (IllegalArgumentException e) {
+            return ApiResponse.fail(e.getMessage());
+        }
+    }
+
+
     @Operation(summary = "축제 북마크 삭제", description = "축제 ID로 북마크를 삭제합니다.")
     @DeleteMapping("/{festivalId}")
     public ResponseEntity<Void> deleteBookmark(Principal principal,
@@ -65,6 +85,4 @@ public class BookmarkController {
         bookmarkService.deleteBookmark(userId, festivalId);
         return ResponseEntity.noContent().build();
     }
-
-
 }

--- a/src/main/java/com/hackathon_5/Yogiyong_In/dto/Bookmark/BookmarkIdListResDto.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/dto/Bookmark/BookmarkIdListResDto.java
@@ -1,0 +1,15 @@
+//1) DTO id 전용_북마크에서 다른 정보말고 축제 아이디만
+// src/main/java/com/hackathon_5/Yogiyong_In/dto/Bookmark/BookmarkIdListResDto.java
+package com.hackathon_5.Yogiyong_In.dto.Bookmark;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter @AllArgsConstructor @Builder
+public class BookmarkIdListResDto {
+    private int count;
+    private List<Integer> festivalIds;
+}

--- a/src/main/java/com/hackathon_5/Yogiyong_In/repository/BookmarkRepository.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/repository/BookmarkRepository.java
@@ -1,3 +1,4 @@
+
 package com.hackathon_5.Yogiyong_In.repository;
 
 import com.hackathon_5.Yogiyong_In.domain.Bookmark;
@@ -11,21 +12,31 @@ import java.util.List;
 import java.util.Optional;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+
     boolean existsByUserAndFestival(User user, Festival festival);
     Optional<Bookmark> findByUserAndFestival(User user, Festival festival);
     List<Bookmark> findAllByUser(User user);
 
     @Query("""
-        select new com.hackathon_5.Yogiyong_In.dto.Festival.PopularFestivalDto(
-            f.festivalId, f.festivalName, f.festivalDesc,
-            f.festivalStart, f.festivalEnd, f.festivalLoca, f.imagePath,
-            count(b)
-        )
-        from Bookmark b
-        join b.festival f
-        group by f.festivalId, f.festivalName, f.festivalDesc,
-                 f.festivalStart, f.festivalEnd, f.festivalLoca, f.imagePath
-        order by count(b) desc, f.festivalStart desc
-    """)
+            select new com.hackathon_5.Yogiyong_In.dto.Festival.PopularFestivalDto(
+                f.festivalId, f.festivalName, f.festivalDesc,
+                f.festivalStart, f.festivalEnd, f.festivalLoca, f.imagePath,
+                count(b)
+            )
+            from Bookmark b
+            join b.festival f
+            group by f.festivalId, f.festivalName, f.festivalDesc,
+                     f.festivalStart, f.festivalEnd, f.festivalLoca, f.imagePath
+            order by count(b) desc, f.festivalStart desc
+            """)
     List<PopularFestivalDto> findPopularFestivals(Pageable pageable);
+
+    // [ADD] ID만 조회하는 쿼리 추가
+    @Query("""
+            select b.festival.festivalId
+            from Bookmark b
+            where b.user = :user
+            order by b.id desc
+            """)
+    List<Integer> findFestivalIdsByUser(User user);
 }

--- a/src/main/java/com/hackathon_5/Yogiyong_In/service/BookmarkService.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/service/BookmarkService.java
@@ -57,6 +57,19 @@ public class BookmarkService {
                 .build();
     }
 
+    // [ADD] 추가
+    public BookmarkIdListResDto getMyBookmarkFestivalIds(String userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        List<Integer> ids = bookmarkRepository.findFestivalIdsByUser(user);
+
+        return BookmarkIdListResDto.builder()
+                .count(ids.size())
+                .festivalIds(ids)
+                .build();
+    }
+
     public void deleteBookmark(String userId, Integer festivalId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
@@ -69,3 +82,4 @@ public class BookmarkService {
         bookmarkRepository.delete(bookmark);
     }
 }
+


### PR DESCRIPTION
## 주요 변경
- BookmarkIdListResDto 추가 (festivalId만 반환)
- BookmarkRepository: festivalId만 조회하는 쿼리 추가
- BookmarkService: getMyBookmarkFestivalIds(userId) 추가
- BookmarkController: /api/mypage/bookmarks/ids 엔드포인트 추가

## 테스트
- Swagger에서 /api/mypage/bookmarks/ids 호출 시 festivalIds 배열만 반환됨 확인
- 기존 /api/mypage/bookmarks 응답 영향 없음
