### PR TITLE
Feature/add recommendation title

### DIFF
--- a/src/main/java/com/hackathon_5/Yogiyong_In/controller/FestivalRecommendController.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/controller/FestivalRecommendController.java
@@ -2,7 +2,7 @@ package com.hackathon_5.Yogiyong_In.controller;
 
 import com.hackathon_5.Yogiyong_In.dto.ApiResponse;
 import com.hackathon_5.Yogiyong_In.dto.AiRecommend.FestivalRecommendGetResDto;
-import com.hackathon_5.Yogiyong_In.dto.Festival.FestivalsByKeywordResDto; // import 추가
+import com.hackathon_5.Yogiyong_In.dto.Festival.FestivalsByKeywordResDto;
 import com.hackathon_5.Yogiyong_In.service.FestivalRecommendService;
 import com.hackathon_5.Yogiyong_In.service.FestivalService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,28 +26,21 @@ public class FestivalRecommendController {
     private final FestivalRecommendService recommendService;
     private final FestivalService festivalService;
 
+    //  [수정] recommend 메소드를 아래 내용으로 교체했습니다.
     @Operation(
-            summary = "AI 축제 추천",
-            description = "로그인한 사용자의 선택 키워드를 기반으로 AI가 축제를 추천합니다.",
+            summary = "AI 축제 추천 (키워드별 그룹)",
+            description = "로그인한 사용자의 선택 키워드별로 AI가 추천하는 축제 목록을 그룹화하여 반환합니다.",
             security = { @SecurityRequirement(name = "bearerAuth") }
     )
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/recommend")
-    public ResponseEntity<ApiResponse<FestivalRecommendGetResDto>> recommend(
+    public ApiResponse<List<FestivalRecommendGetResDto>> recommend(
             Authentication authentication,
             @RequestParam(name = "limit", required = false, defaultValue = "5") Integer limit
     ) {
         String userId = authentication.getName();
-        var result = recommendService.recommend(userId, limit);
-        var body = ApiResponse.ok(result.data());
-
-        if (result.message() == null || result.message().isBlank()) {
-            return ResponseEntity.ok(body);
-        } else {
-            return ResponseEntity.ok()
-                    .header("X-Info-Message", result.message())
-                    .body(body);
-        }
+        List<FestivalRecommendGetResDto> result = recommendService.recommend(userId, limit);
+        return ApiResponse.ok(result);
     }
 
     @Operation(

--- a/src/main/java/com/hackathon_5/Yogiyong_In/dto/AiRecommend/FestivalRecommendGetResDto.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/dto/AiRecommend/FestivalRecommendGetResDto.java
@@ -6,6 +6,7 @@ import java.util.List;
 @Getter @Setter
 @NoArgsConstructor @AllArgsConstructor @Builder
 public class FestivalRecommendGetResDto {
+    private String title; //이름 보내주기.
     private List<FestivalRecommendGetItemDto> items; // 추천 축제 목록
     private int totalCount;                           // 총 개수
 }

--- a/src/main/java/com/hackathon_5/Yogiyong_In/dto/AiRecommend/FestivalRecommendGetResDto.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/dto/AiRecommend/FestivalRecommendGetResDto.java
@@ -6,7 +6,9 @@ import java.util.List;
 @Getter @Setter
 @NoArgsConstructor @AllArgsConstructor @Builder
 public class FestivalRecommendGetResDto {
-    private String title; //이름 보내주기.
+    private String title; //★ 제목필드 추가
     private List<FestivalRecommendGetItemDto> items; // 추천 축제 목록
     private int totalCount;                           // 총 개수
 }
+
+

--- a/src/main/java/com/hackathon_5/Yogiyong_In/service/FestivalRecommendService.java
+++ b/src/main/java/com/hackathon_5/Yogiyong_In/service/FestivalRecommendService.java
@@ -5,9 +5,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.genai.Client;
 import com.google.genai.types.GenerateContentConfig;
 import com.google.genai.types.GenerateContentResponse;
+import com.hackathon_5.Yogiyong_In.domain.Festival;
+import com.hackathon_5.Yogiyong_In.domain.UserKeyword;
 import com.hackathon_5.Yogiyong_In.dto.AiRecommend.FestivalRecommendGetItemDto;
 import com.hackathon_5.Yogiyong_In.dto.AiRecommend.FestivalRecommendGetResDto;
-import com.hackathon_5.Yogiyong_In.domain.Festival;
 import com.hackathon_5.Yogiyong_In.repository.FestivalRepository;
 import com.hackathon_5.Yogiyong_In.repository.UserKeywordRepository;
 import lombok.RequiredArgsConstructor;
@@ -37,120 +38,77 @@ public class FestivalRecommendService {
 
     private final ObjectMapper om = new ObjectMapper();
 
+    // ✅ [수정] recommend 메소드를 아래 내용으로 완전히 교체합니다.
     @Transactional(readOnly = true)
-    public FestivalRecommendResult recommend(String userId, Integer limit) {
+    public List<FestivalRecommendGetResDto> recommend(String userId, Integer limit) {
+        // 1) 사용자 선택 키워드(엔티티) 목록 가져오기
+        List<UserKeyword> selectedUserKeywords = userKeywordRepository.findByUser_UserIdAndIsSelectedTrue(userId);
 
-        // 1) 사용자 선택 키워드(표시명 + slug)
-        var selected = userKeywordRepository.findByUser_UserIdAndIsSelectedTrue(userId);
-        var keywordNames = selected.stream() // 프롬프트 표기용
-                .map(uk -> uk.getKeyword().getKeywordName())
-                .filter(Objects::nonNull).map(String::trim)
-                .filter(s -> !s.isBlank()).distinct().toList();
-
-        // [ADD] ✅ 키워드로 제목 생성
-        String title = "'" + String.join(", ", keywordNames) + "' 축제";
-
-        var keywordSlugs = selected.stream() // 내부 로직용(한글 slug)
-                .map(uk -> uk.getKeyword().getSlug())
-                .filter(Objects::nonNull).map(String::trim)
-                .filter(s -> !s.isBlank()).distinct().toList();
-
-        if (keywordNames.isEmpty()) {
+        if (selectedUserKeywords.isEmpty()) {
             log.debug("[AI-RECO] userId={} has no selected keywords", userId);
-            // [FIX] ✅ 키워드가 없을 때도 title 필드를 포함하도록 수정
-            return new FestivalRecommendResult(
-                    FestivalRecommendGetResDto.builder()
-                            .title("추천 축제") // 기본 제목 설정
-                            .items(List.of())
-                            .totalCount(0)
-                            .build(),
-                    "선택된 키워드가 없어 추천 결과가 없습니다."
-            );
+            return new ArrayList<>(); // 키워드가 없으면 빈 리스트 반환
         }
 
-        // 2) 축제 카탈로그 로딩
-        var all = festivalRepository.findAll();
-        if (all.isEmpty()) {
-            log.debug("[AI-RECO] No festivals in catalog");
-            // [FIX] ✅ 데이터가 없을 때도 title 필드를 포함하도록 수정
-            return new FestivalRecommendResult(
-                    FestivalRecommendGetResDto.builder()
-                            .title(title)
-                            .items(List.of())
-                            .totalCount(0)
-                            .build(),
-                    "등록된 축제 데이터가 없어 추천할 수 없습니다."
-            );
-        }
-
-        // 2-1) 계절 우선 선별/정렬
-        var seasonMonths = seasonMonthsBySlugs(keywordSlugs); // 예) [3,4,5] 등
-        List<Festival> catalog = all;
-        if (!seasonMonths.isEmpty()) {
-            // 계절 점수 + 보조 점수(이름/설명에 계절 단어가 있으면 소폭 가점)
-            catalog = all.stream()
-                    .sorted(Comparator.comparingInt((Festival f) -> seasonScore(f, seasonMonths))
-                            .thenComparingInt(f -> textSeasonBias(f, seasonMonths))
-                            .reversed())
-                    .limit(CATALOG_MAX)
-                    .toList();
-        } else {
-            catalog = all.stream().limit(CATALOG_MAX).toList();
-        }
-
-        // 3) 프롬프트
-        int topN = (limit == null || limit <= 0) ? DEFAULT_TOP_N : limit;
-        String prompt = buildPromptIdsOnly(keywordNames, seasonMonths, catalog, topN);
-
-        // 4) Gemini 호출
-        String aiText = callGemini(prompt);
-        if (aiText.isBlank()) {
-            log.warn("[AI-RECO] Empty response from Gemini");
-            // [FIX] ✅ AI 응답이 없을 때도 title 필드를 포함하도록 수정
-            return new FestivalRecommendResult(
-                    FestivalRecommendGetResDto.builder()
-                            .title(title)
-                            .items(List.of())
-                            .totalCount(0)
-                            .build(),
-                    "AI 응답이 비어 있어 추천 결과가 없습니다."
-            );
-        }
-
-        // 5) 응답 파싱
-        List<Integer> ids = parseFestivalIds(aiText);
-        if (ids.isEmpty()) {
-            log.warn("[AI-RECO] No ids parsed from Gemini response: {}", aiText);
-            // [FIX] ✅ 파싱 실패 시에도 title 필드를 포함하도록 수정
-            return new FestivalRecommendResult(
-                    FestivalRecommendGetResDto.builder()
-                            .title(title)
-                            .items(List.of())
-                            .totalCount(0)
-                            .build(),
-                    "AI 응답을 해석하지 못해 추천 결과가 없습니다."
-            );
-        }
-
-        // 6) 매핑 → DTO
-        Map<Integer, Festival> byId = catalog.stream()
+        // 2) 전체 축제 카탈로그 한 번만 로딩해서 Map으로 변환 (조회 성능 향상)
+        Map<Integer, Festival> festivalMap = festivalRepository.findAll().stream()
                 .collect(Collectors.toMap(Festival::getFestivalId, f -> f));
 
-        var items = ids.stream()
-                .map(byId::get)
-                .filter(Objects::nonNull)
-                .map(this::toItemDto)
-                .toList();
+        if (festivalMap.isEmpty()) {
+            log.debug("[AI-RECO] No festivals in catalog");
+            return new ArrayList<>();
+        }
+        List<Festival> allFestivals = new ArrayList<>(festivalMap.values());
 
-        // [FIX] ✅ 최종 반환 DTO에 생성한 title 추가
-        var data = FestivalRecommendGetResDto.builder()
-                .title(title)
-                .items(items)
-                .totalCount(items.size())
-                .build();
+        // 3) 최종 결과를 담을 리스트 생성 (반환 타입이 List<FestivalRecommendGetResDto>로 변경)
+        List<FestivalRecommendGetResDto> finalResult = new ArrayList<>();
 
-        String msg = items.isEmpty() ? "조건에 맞는 추천 축제가 없습니다." : null;
-        return new FestivalRecommendResult(data, msg);
+        // 4) ★ 각 키워드별로 루프를 돌며 AI 추천 요청
+        for (UserKeyword userKeyword : selectedUserKeywords) {
+            String keywordName = userKeyword.getKeyword().getKeywordName();
+            String keywordSlug = userKeyword.getKeyword().getSlug();
+
+            // 4-1) 현재 키워드로 제목 생성
+            String title = "'" + keywordName + "' 축제";
+
+            // 4-2) 현재 키워드 하나만으로 AI 프롬프트 생성
+            String prompt = buildPromptForKeyword(keywordName, keywordSlug, allFestivals, limit);
+
+            // 4-3) AI 호출 및 ID 파싱
+            String aiText = callGemini(prompt);
+            List<Integer> ids = parseFestivalIds(aiText);
+
+            if (ids.isEmpty()) {
+                continue; // 현재 키워드에 대한 추천 결과가 없으면 다음 키워드로 넘어감
+            }
+
+            // 4-4) ID를 축제 정보(DTO)로 변환
+            var items = ids.stream()
+                    .map(festivalMap::get)
+                    .filter(Objects::nonNull)
+                    .map(this::toItemDto)
+                    .toList();
+
+            // 4-5) 현재 키워드 그룹을 FestivalRecommendGetResDto에 담아 최종 리스트에 추가
+            if (!items.isEmpty()) {
+                finalResult.add(
+                        FestivalRecommendGetResDto.builder()
+                                .title(title)
+                                .items(items)
+                                .totalCount(items.size())
+                                .build()
+                );
+            }
+        }
+
+        return finalResult;
+    }
+
+    // ✅ [추가] 루프 안에서 프롬프트를 만드는 로직을 별도 메소드로 분리
+    private String buildPromptForKeyword(String keywordName, String keywordSlug, List<Festival> allFestivals, Integer limit) {
+        var seasonMonths = seasonMonthsBySlugs(List.of(keywordSlug));
+        List<Festival> catalogForPrompt = allFestivals.stream().limit(CATALOG_MAX).toList();
+        int topN = (limit == null || limit <= 0) ? DEFAULT_TOP_N : limit;
+        return buildPromptIdsOnly(List.of(keywordName), seasonMonths, catalogForPrompt, topN);
     }
 
     // --- 이하 다른 메소드들은 그대로 유지 ---
@@ -238,9 +196,6 @@ public class FestivalRecommendService {
         }
     }
 
-    // ---------- 계절 매핑/스코어링 유틸 ----------
-
-    /** 선택한 slug(한글) 목록에서 계절 월 집합을 만든다. */
     private Set<Integer> seasonMonthsBySlugs(List<String> slugs) {
         Set<Integer> ms = new HashSet<>();
         if (slugs == null) return ms;
@@ -251,28 +206,24 @@ public class FestivalRecommendService {
         return ms;
     }
 
-    /** 축제가 선택 월과 겹치면 높은 점수를 부여(겹치는 정도에 따라 가중) */
     private int seasonScore(Festival f, Set<Integer> months) {
         if (months == null || months.isEmpty()) return 0;
         LocalDate s = f.getFestivalStart();
         LocalDate e = f.getFestivalEnd();
         if (s == null && e == null) return 0;
 
-        // 시작/종료 월만 있는 단순 케이스 가중
         int score = 0;
         if (s != null && months.contains(s.getMonthValue())) score += 3;
         if (e != null && months.contains(e.getMonthValue())) score += 2;
 
-        // 기간이 길면 월 겹침을 추가 가점(간단 루프)
         if (s != null && e != null) {
             Set<Integer> span = enumerateMonthsInclusive(s, e);
             long overlap = span.stream().filter(months::contains).count();
-            score += overlap; // 겹치는 월 수만큼 +1
+            score += overlap;
         }
         return score;
     }
 
-    /** 이름/설명에 계절 단어가 등장하면 소폭 가점(보조용) */
     private int textSeasonBias(Festival f, Set<Integer> months) {
         if (months == null || months.isEmpty()) return 0;
         String text = (ns(f.getFestivalName()) + " " + ns(f.getFestivalDesc())).toLowerCase();
@@ -288,21 +239,17 @@ public class FestivalRecommendService {
         return b;
     }
 
-    /** 시작~종료 기간의 월을 모두 뽑는다(연도 경계 포함) */
     private Set<Integer> enumerateMonthsInclusive(LocalDate start, LocalDate end) {
         Set<Integer> set = new HashSet<>();
         if (start == null || end == null) return set;
         LocalDate cur = start;
-        int guard = 0; // 무한루프 방지
+        int guard = 0;
         while (!cur.isAfter(end) && guard++ < 370) {
             set.add(cur.getMonthValue());
             cur = cur.plusMonths(1).withDayOfMonth(1);
         }
         return set;
-        // 참고: start > end인 비정상 데이터는 상단 seasonScore에서 처리하지 않음
     }
-
-    // ---------- 공통 유틸 ----------
 
     private static String ns(String s){ return s == null ? "" : s; }
     private static String trim(String s, int max){


### PR DESCRIPTION


### **PR 설명:**

## 📄 요약 (Summary)

AI 축제 추천 API의 응답 구조를 리팩토링하여, 사용자가 선택한 **각 키워드별로 추천 축제 목록을 그룹화**하여 반환하도록 변경했습니다.

## motiva Motivation

프론트엔드에서 키워드별로 구분된 UI를 구현하기 위해, API 응답이 키워드 단위로 그룹화된 데이터 구조로 제공되어야 한다는 요구사항이 있었습니다. 기존에는 모든 키워드를 종합한 단일 목록만 반환하여 이를 구현할 수 없었습니다.

## 📝 주요 변경 사항 (Key Changes)

  - **`FestivalRecommendGetResDto` 수정**:

      - 기존 DTO를 '단일 키워드 그룹'의 역할을 하도록 재정의하고, 그룹 제목을 담는 `String title` 필드를 추가했습니다.

  - **`FestivalRecommendService` 수정**:

      - `recommend` 메소드의 로직을 **전면 수정**했습니다.
      - 사용자가 선택한 각 키워드에 대해 `for` 루프를 실행하며, **키워드마다 개별적으로 Gemini AI API를 호출**하여 추천 결과를 받습니다.
      - 각 키워드별 결과를 `FestivalRecommendGetResDto`에 담아 `List`로 만들어 최종 반환합니다.

  - **`FestivalRecommendController` 수정**:

      - API의 최종 반환 타입을 `ApiResponse<List<FestivalRecommendGetResDto>>`로 변경하여, 그룹 목록을 반환하도록 수정했습니다.

## 🖼️ API 응답 예시 (API Response Example)

  - **AS-IS (변경 전)**: `{ "items": [...] }` (단일 객체)
  - **TO-BE (변경 후)**: `[ { "title": "...", "items": [...] }, { ... } ]` (객체의 배열)

<!-- end list -->

```json
[
  {
    "title": "'음악' 축제",
    "items": [...],
    "totalCount": 2
  },
  {
    "title": "'여름' 축제",
    "items": [...],
    "totalCount": 3
  }
]
```

## 📢 리뷰어에게 (To Reviewers)

  - 요구사항 변경으로 서비스 로직이 키워드별로 AI를 여러 번 호출하는 구조로 바뀌었습니다.
  - 현재는 기능 구현에 초점을 맞췄으나, 추후 키워드가 많아질 경우 **성능 및 비용 문제가 발생할 수 있습니다.** (최적화 필요)
  - 이 점을 인지하고 리뷰 부탁드립니다.